### PR TITLE
Modify travis to start running builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,9 @@ matrix:
   - stage: deploy_edge
     name: "Deploy Edge Release"
     jdk: openjdk8
-  before_script:
-    - export PROJECT_MAVEN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-    - export TRAVIS_TAG=${TRAVIS_TAG:-$PROJECT_MAVEN_VERSION+$(date +'%Y%m%d%H%M%S')-$TRAVIS_COMMIT}
+    before_script:
+      - export PROJECT_MAVEN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+      - export TRAVIS_TAG=${TRAVIS_TAG:-$PROJECT_MAVEN_VERSION+$(date +'%Y%m%d%H%M%S')-$TRAVIS_COMMIT}
     script:
       - mvn package -DskipTests -Dcheckstyle.skip=true
       #- docker build -f install/docker/Dockerfile -t airsonic/airsonic:latest -t airsonic/airsonic:edge/$TRAVIS_TAG .

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,23 @@ cache:
   directories:
     - $HOME/.m2
 
+# do not build on tagged commits to avoid infinite loops
+if: tag is blank
+
 #services:
 #  - docker
 
-#env:
-#  global:
+env:
+  global:
+    # GITHUB_OAUTH_TOKEN=<token>
+    - secure: "wiQ9KeD2WfFUrct+VdKjBi83K2S2muy8CT+MqbgpK/hDuIFluUBPz4lDCXBS8dtk1pwE7Zz9Zlu15QZO4SvEFH73QmzseTnaW8E51PCtzih/8AY9X34g1SYqkYZehixPMmDRknhHn+VocZjGJW9GhKqta34viz3WPi6MRqdtsMYR6gf3FXz8HBJbqVHJU0nOdeUzIM4MG674TFupm66t8QtilCLEWwWM0/aSvWAEMFLrHJUehJOe2IakRnMYD07BKIluBG46oUszZ11FXuWGHLKZTgz7FYavCiyT6HMjFI5p5Tpn42FLUz6GGFZ2xWYSc7oXT//eNWVy6lvGK8OvNmo6iPF2e5hfUqdVrPfKW72PwmCnSJqMyQRCWcfyop15sykiS4ThMXXBeo1QxAlVDU1+BMF/Dx9Ho+AEd3jOLnkpmfc/WWpODDrmrM0b2WvcVpIbMZV7dKVt9sV/LIV1f7TvWhUP6TfXhowPjGVN1SoQ6oWzI1e7ibxWkADMIX/sUIqWgC7FSgN+KIHBC3pFonx+peFesLDXZmu1aeXQZ8pC7GiWUhfNQlEz2Cyz70GGYQ2YN478pganfvyDo0ynPrc2fvsNEg/6TGCif9xAzIK+gRFY5qrOZpoAZ6yg9U8YWqX9EQRRK20WMiCAH+A90plnD0qYEWkvYeKHkYNFPD0="
 #    - secure: "encrypted DOCKER_USERNAME=user"
 #    - secure: "encrypted DOCKER_PASSWORD=pass"
       
 stages:
   - name: deploy_edge
     # deploy only on commits to master branch
-    if: branch = master && type = push
+    if: branch = master && type = push && tag is blank
 
 script:
   - mvn verify -B -P integration-test
@@ -59,18 +64,18 @@ matrix:
     before_deploy:
       # Set up git user name and tag this commit
       - git config --local user.name "Airsonic Travis CI"
-      - git config --local user.email "airsonicadvanced@gmail.com"
-      - git tag $TRAVIS_TAG -m "Edge Release $TRAVIS_TAG"
+      - git config --local user.email "builds@travis-ci.org"
+      - git tag $TRAVIS_TAG -a -m "Generated tag $TRAVIS_TAG from Travis CI for build $TRAVIS_BUILD_NUMBER"
+      - git push -q https://$GITHUB_OAUTH_TOKEN@github.com/airsonic-advanced/airsonic-advanced --tags
     deploy:
     - provider: releases
-      api_key:
-        secure: "I0aBwJhFlCjXmsVFffUMbR38wHp+HrsTBkYKePxWn5+prYgq+9dSz0IjWpHEszUdnCDQcHEJR4nFS2YLEBdEzC4sqkWZVpJEnSVF/izEbxjxb1fNdLeCqZAPkuqw5/pta9JKwdwFMvBLKkV+lBaXscr/sLipAtOIESs+EV1zP5GU0636s4IWA85yfrhKEgE2cjQqtgpbcIZXJWbZN+MtmAhSgeKvUzYGTjOFmF/xfO3ksBAAUd3j0bmsAgA/9+I5XCsR/IRW/PLLdi2ocwsHY+VqdrH4p5kHN3EV2MrjtvhbrRYRFdRoYcux5EXupdTOIMz03GW4wbPJm90hKa2BbaWkzHF9hv6X5boPFrOP+7XqW01X7FVp9dGringEv8CPd+iNPqJLrISDjztnWVuRxpcoJbKEaObYR3DXNyQJ5nbGlrp8vmqRPC2nIJT6UqgE2Bqcap4a1NBVXVQ/zjCCJbDv44QGYWGCL0WIbxOvsWKWvd1otqHi07x8nOAhivoBI44q7UGIoGg0BTs8+EXbbpoAu4cNgLteipByEdtoXnYA7P+L3QLR7kBY5Qyc0bwI2UyE9JlxJMb/90701DMCcKuzvW14aEsVeu00j53UEUCV+i2lKMBZf67VIFQuUvgtUhzzJcvlMaElqh8OrPImRhUkMV9HMY2+qyrHc5CucDg="
+      api_key: $GITHUB_OAUTH_TOKEN
       file: airsonic-main/target/airsonic.war
       skip_cleanup: true
       options:
         - prerelease: true
         - name: "Edge Release $TRAVIS_TAG"
       on:
-        tags: true
+        tags: false
     #- provider: script
     #  script: bash install/docker/dockerhub_push.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ cache:
   directories:
     - $HOME/.m2
 
-services:
-  - docker
+#services:
+#  - docker
 
-env:
-  global:
-    - secure: "encrypted DOCKER_USERNAME=user"
-    - secure: "encrypted DOCKER_PASSWORD=pass"
+#env:
+#  global:
+#    - secure: "encrypted DOCKER_USERNAME=user"
+#    - secure: "encrypted DOCKER_PASSWORD=pass"
       
 stages:
   - name: deploy_edge
@@ -30,9 +30,9 @@ matrix:
     addons:
       coverity_scan:
         project:
-          name: "airsonic/airsonic"
+          name: "airsonic-advanced/airsonic-advanced"
           description: "A Free and Open Source community driven media server"
-        notification_email: "airsonic@tutanota.com"
+        notification_email: "airsonicadvanced@gmail.com"
         build_command_prepend:
         build_command: mvn -B -q clean package -DskipTests=true
         branch_pattern: master
@@ -55,16 +55,16 @@ matrix:
     - export TRAVIS_TAG=${TRAVIS_TAG:-$PROJECT_MAVEN_VERSION+$(date +'%Y%m%d%H%M%S')-$TRAVIS_COMMIT}
     script:
       - mvn package -DskipTests -Dcheckstyle.skip=true
-      - docker build -f install/docker/Dockerfile -t airsonic/airsonic:latest -t airsonic/airsonic:edge/$TRAVIS_TAG .
+      #- docker build -f install/docker/Dockerfile -t airsonic/airsonic:latest -t airsonic/airsonic:edge/$TRAVIS_TAG .
     before_deploy:
       # Set up git user name and tag this commit
-      - git config --local user.name "Airsonic Travis"
-      - git config --local user.email "airsonic@tutanota.com"
+      - git config --local user.name "Airsonic Travis CI"
+      - git config --local user.email "airsonicadvanced@gmail.com"
       - git tag $TRAVIS_TAG -m "Edge Release $TRAVIS_TAG"
     deploy:
     - provider: releases
       api_key:
-        secure: "encrypted GITHUB_OAUTH_TOKEN"
+        secure: "I0aBwJhFlCjXmsVFffUMbR38wHp+HrsTBkYKePxWn5+prYgq+9dSz0IjWpHEszUdnCDQcHEJR4nFS2YLEBdEzC4sqkWZVpJEnSVF/izEbxjxb1fNdLeCqZAPkuqw5/pta9JKwdwFMvBLKkV+lBaXscr/sLipAtOIESs+EV1zP5GU0636s4IWA85yfrhKEgE2cjQqtgpbcIZXJWbZN+MtmAhSgeKvUzYGTjOFmF/xfO3ksBAAUd3j0bmsAgA/9+I5XCsR/IRW/PLLdi2ocwsHY+VqdrH4p5kHN3EV2MrjtvhbrRYRFdRoYcux5EXupdTOIMz03GW4wbPJm90hKa2BbaWkzHF9hv6X5boPFrOP+7XqW01X7FVp9dGringEv8CPd+iNPqJLrISDjztnWVuRxpcoJbKEaObYR3DXNyQJ5nbGlrp8vmqRPC2nIJT6UqgE2Bqcap4a1NBVXVQ/zjCCJbDv44QGYWGCL0WIbxOvsWKWvd1otqHi07x8nOAhivoBI44q7UGIoGg0BTs8+EXbbpoAu4cNgLteipByEdtoXnYA7P+L3QLR7kBY5Qyc0bwI2UyE9JlxJMb/90701DMCcKuzvW14aEsVeu00j53UEUCV+i2lKMBZf67VIFQuUvgtUhzzJcvlMaElqh8OrPImRhUkMV9HMY2+qyrHc5CucDg="
       file: airsonic-main/target/airsonic.war
       skip_cleanup: true
       options:
@@ -72,5 +72,5 @@ matrix:
         - name: "Edge Release $TRAVIS_TAG"
       on:
         tags: true
-    - provider: script
-      script: bash install/docker/dockerhub_push.sh
+    #- provider: script
+    #  script: bash install/docker/dockerhub_push.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,26 @@ language: java
 cache:
   directories:
     - $HOME/.m2
+
+services:
+  - docker
+
+env:
+  global:
+    - secure: "encrypted DOCKER_USERNAME=user"
+    - secure: "encrypted DOCKER_PASSWORD=pass"
+      
+stages:
+  - name: deploy_edge
+    # deploy only on commits to master branch
+    if: branch = master && type = push
+
 script:
   - mvn verify -B -P integration-test
 
 matrix:
   include:
+  # tests
   - name: coverity
     script:
       - echo "coverity scan script"
@@ -30,3 +45,32 @@ matrix:
   - jdk: openjdk11
   - jdk: openjdk12
   - jdk: openjdk13
+  
+  # deploys
+  - stage: deploy_edge
+    name: "Deploy Edge Release"
+    jdk: openjdk8
+  before_script:
+    - export PROJECT_MAVEN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+    - export TRAVIS_TAG=${TRAVIS_TAG:-$PROJECT_MAVEN_VERSION+$(date +'%Y%m%d%H%M%S')-$TRAVIS_COMMIT}
+    script:
+      - mvn package -DskipTests -Dcheckstyle.skip=true
+      - docker build -f install/docker/Dockerfile -t airsonic/airsonic:latest -t airsonic/airsonic:edge/$TRAVIS_TAG .
+    before_deploy:
+      # Set up git user name and tag this commit
+      - git config --local user.name "Airsonic Travis"
+      - git config --local user.email "airsonic@tutanota.com"
+      - git tag $TRAVIS_TAG -m "Edge Release $TRAVIS_TAG"
+    deploy:
+    - provider: releases
+      api_key:
+        secure: "encrypted GITHUB_OAUTH_TOKEN"
+      file: airsonic-main/target/airsonic.war
+      skip_cleanup: true
+      options:
+        - prerelease: true
+        - name: "Edge Release $TRAVIS_TAG"
+      on:
+        tags: true
+    - provider: script
+      script: bash install/docker/dockerhub_push.sh

--- a/install/docker/dockerhub_push.sh
+++ b/install/docker/dockerhub_push.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker push airsonic/airsonic:latest
+docker push airsonic/airsonic:edge/$TRAVIS_TAG


### PR DESCRIPTION
This PR automates dev builds to be pushed out to GitHub Releases ~and Docker Hub~ under the Edge Release Channel per discussion in ~https://github.com/airsonic/airsonic/issues/1373~

I also think we should automate the Stable Releases, but that's a later priority. I'm eager to get the dev builds going so the massive backlog of PRs is reduced.

This PR:
- Divides builds into 2 stages: `test` and `deploy_edge`
- `deploy_edge` only runs
  - on `master`
  - for merges/pushes (i.e. no PRs)
  - If all jobs in the `test` stage pass
- Edge deploys
  - Build airsonic war
  - Build the docker container
  - Tag the commit it's building on (necessary for GitHub Release)
  - push to GitHub Releases with a Preleaase Build
  - ~push to Docker Hub~
  - Tags are of the type `MAVEN_BUILD+DATETIMEOFBUILD+COMMITHASH` in keeping with Semantic Versioning
    - E.g. `10.5.0-SNAPSHOT+20191029183312-a9a7b082`
  - Deploys to ~both Docker Hub and~ GitHub Releases are done on the Edge Release Channel, and doesn't affect the Stable Release

This PR needs the following from the maintainer(s):
  - Generation of a GITHUB_OAUTH_TOKEN with appropriate privileges from the GitHub settings page of the repo. This is for Travis to use.
  - Encryption of the following strings with the travis public key for the repo, and insertion into appropriate place in the PR
    - `<GITHUB_OAUTH_TOKEN>` generated above
    - ~`DOCKER_USERNAME=<dockerusername>`~
    - ~`DOCKER_PASSWORD=<dockerpassword>`~
  - For encryption, you may use the `travis` gem or do it manually with the travis public key. More reading here: https://docs.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml

Notes:
  - I considered adding automatic Changelog building commits so manual changelog updates aren't required, but we can add that later.
  - Stable releases are still manual for now. We need to see if this build works appropriately.

The bulk of this PR was authored in https://github.com/airsonic/airsonic/pull/1383