### PR TITLE
Spring Boot 2 Upgrade: Part 3 - Remove DBCP2, switch to Tomcat/Hikari

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -144,20 +144,6 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- connection pool manager, fixes #860 (external database performance) -->  
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-dbcp2</artifactId>
-            <version>2.5.0</version>
-            <!-- this wants to pull in commons-logging v1.2 which conflicts with other dependencies -->
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>

--- a/airsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
@@ -4,7 +4,6 @@ import liquibase.database.DatabaseFactory;
 import liquibase.integration.spring.SpringLiquibase;
 import org.airsonic.player.service.SettingsService;
 import org.airsonic.player.util.Util;
-import org.apache.commons.dbcp2.BasicDataSource;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
@@ -49,8 +48,7 @@ public class DatabaseConfiguration {
     @Profile("embed")
     public DataSource embedDataSource() {
         return DataSourceBuilder.create()
-                //connection pool
-                .type(BasicDataSource.class)
+                //find connection pool automatically
                 .username(user)
                 .password(password)
                 .driverClassName(driver)


### PR DESCRIPTION
This builds on #18 and #21 and switches the DB connection pool to the default provided by Spring boot, removing explicit dependency to Apache's DBCP2 in the process.

The default is either Hikari, Tomcat, or DBCP2, whichever is found on the system first, in that order.

This is Step 3 of a series of PRs each of which will build on each other

Next up: Testing rules

This is the same PR as https://github.com/airsonic/airsonic/pull/1368