### PR TITLE
Spring Boot 2 Upgrade: Part 4 - Move Tests to Rules

### DIFF
--- a/airsonic-main/src/test/java/org/airsonic/player/dao/DaoTestCaseBean2.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/dao/DaoTestCaseBean2.java
@@ -2,29 +2,17 @@ package org.airsonic.player.dao;
 
 import org.airsonic.player.util.HomeRule;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.context.junit4.SpringRunner;
 
+@RunWith(SpringRunner.class)
 @SpringBootTest
 public class DaoTestCaseBean2 {
     @ClassRule
-    public static final SpringClassRule classRule = new SpringClassRule() {
-        HomeRule airsonicRule = new HomeRule();
-        @Override
-        public Statement apply(Statement base, Description description) {
-            Statement newBase = airsonicRule.apply(base, description);
-            return super.apply(newBase, description);
-        }
-    };
-
-    @Rule
-    public final SpringMethodRule springMethodRule = new SpringMethodRule();
+    public static final HomeRule airsonicRule = new HomeRule();
 
     @Autowired
     GenericDaoHelper genericDaoHelper;

--- a/airsonic-main/src/test/java/org/airsonic/player/service/LegacyDatabaseStartupTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/LegacyDatabaseStartupTestCase.java
@@ -7,11 +7,16 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
+
+import javax.sql.DataSource;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -28,9 +33,12 @@ public class LegacyDatabaseStartupTestCase {
         org.airsonic.player.util.FileUtils.copyResourcesRecursively(LegacyDatabaseStartupTestCase.class.getResource("/db/pre-liquibase/db"), new File(homeParent));
     }
     
+    @Autowired
+    DataSource dataSource;
+    
     @Test
     public void testStartup() {
-        System.out.println("Successful startup");
+        assertThat(dataSource).isNotNull();
     }
 
 }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/LegacyDatabaseStartupTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/LegacyDatabaseStartupTestCase.java
@@ -31,6 +31,9 @@ public class LegacyDatabaseStartupTestCase {
         File dbDirectory = new File(homeParent, "/db");
         FileUtils.forceMkdir(dbDirectory);
         org.airsonic.player.util.FileUtils.copyResourcesRecursively(LegacyDatabaseStartupTestCase.class.getResource("/db/pre-liquibase/db"), new File(homeParent));
+        // have to change the url here because old db files are libresonic
+        System.setProperty("DatabaseConfigEmbedUrl",
+                SettingsService.getDefaultJDBCUrl().replaceAll("airsonic$", "libresonic"));
     }
     
     @Autowired

--- a/airsonic-main/src/test/java/org/airsonic/player/service/LegacyDatabaseStartupTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/LegacyDatabaseStartupTestCase.java
@@ -3,45 +3,31 @@ package org.airsonic.player.service;
 import org.airsonic.player.TestCaseUtils;
 import org.airsonic.player.util.HomeRule;
 import org.apache.commons.io.FileUtils;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.File;
+import java.io.IOException;
 
+@RunWith(SpringRunner.class)
 @SpringBootTest
 public class LegacyDatabaseStartupTestCase {
 
     @ClassRule
-    public static final SpringClassRule classRule = new SpringClassRule() {
-        HomeRule airsonicRule = new HomeRule() {
-            @Override
-            protected void before() throws Throwable {
-                super.before();
-                String homeParent = TestCaseUtils.airsonicHomePathForTest();
-                System.setProperty("airsonic.home", TestCaseUtils.airsonicHomePathForTest());
-                TestCaseUtils.cleanAirsonicHomeForTest();
-                File dbDirectory = new File(homeParent, "/db");
-                FileUtils.forceMkdir(dbDirectory);
-                org.airsonic.player.util.FileUtils.copyResourcesRecursively(getClass().getResource("/db/pre-liquibase/db"), new File(homeParent));
-            }
-        };
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-            Statement spring = super.apply(base, description);
-            return airsonicRule.apply(spring, description);
-        }
-    };
-
-    @Rule
-    public final SpringMethodRule springMethodRule = new SpringMethodRule();
-
+    public static final HomeRule airsonicRule = new HomeRule();
+    
+    @BeforeClass
+    public static void setupOnce() throws IOException {
+        String homeParent = TestCaseUtils.airsonicHomePathForTest();
+        File dbDirectory = new File(homeParent, "/db");
+        FileUtils.forceMkdir(dbDirectory);
+        org.airsonic.player.util.FileUtils.copyResourcesRecursively(LegacyDatabaseStartupTestCase.class.getResource("/db/pre-liquibase/db"), new File(homeParent));
+    }
+    
     @Test
     public void testStartup() {
         System.out.println("Successful startup");

--- a/airsonic-main/src/test/java/org/airsonic/player/service/LegacyDatabaseStartupTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/LegacyDatabaseStartupTestCase.java
@@ -11,12 +11,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import javax.sql.DataSource;
 
 import java.io.File;
 import java.io.IOException;
 
-import javax.sql.DataSource;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
@@ -17,13 +17,11 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -48,23 +46,13 @@ import static org.junit.Assert.assertNotNull;
  * At runtime, the subsonic_home dir is set to target/test-classes/org/airsonic/player/service/mediaScannerServiceTestCase.
  * An empty database is created on the fly.
  */
+@RunWith(SpringRunner.class)
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class MediaScannerServiceTestCase {
 
     @ClassRule
-    public static final SpringClassRule classRule = new SpringClassRule() {
-        HomeRule airsonicRule = new HomeRule();
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-            Statement spring = super.apply(base, description);
-            return airsonicRule.apply(spring, description);
-        }
-    };
-
-    @Rule
-    public final SpringMethodRule springMethodRule = new SpringMethodRule();
+    public static final HomeRule airsonicRule = new HomeRule();
 
     private final MetricRegistry metrics = new MetricRegistry();
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataFactoryTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataFactoryTestCase.java
@@ -6,13 +6,11 @@ import org.airsonic.player.util.HomeRule;
 import org.apache.commons.io.FileUtils;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,31 +18,13 @@ import java.io.IOException;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+@RunWith(SpringRunner.class)
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class MetaDataFactoryTestCase {
 
     @ClassRule
-    public static final SpringClassRule classRule = new SpringClassRule() {
-        HomeRule airsonicRule = new HomeRule() {
-            @Override
-            protected void before() throws Throwable {
-                super.before();
-                String homeParent = TestCaseUtils.airsonicHomePathForTest();
-                System.setProperty("airsonic.home", TestCaseUtils.airsonicHomePathForTest());
-                TestCaseUtils.cleanAirsonicHomeForTest();
-                File dbDirectory = new File(homeParent, "/db");
-                FileUtils.forceMkdir(dbDirectory);
-                org.airsonic.player.util.FileUtils.copyResourcesRecursively(getClass().getResource("/db/pre-liquibase/db"), new File(homeParent));
-            }
-        };
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-            Statement spring = super.apply(base, description);
-            return airsonicRule.apply(spring, description);
-        }
-    };
+    public static final HomeRule airsonicRule = new HomeRule();
 
     @ClassRule
     public static TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -55,13 +35,16 @@ public class MetaDataFactoryTestCase {
 
     @BeforeClass
     public static void createTestFiles() throws IOException {
+        String homeParent = TestCaseUtils.airsonicHomePathForTest();
+        
+        File dbDirectory = new File(homeParent, "/db");
+        FileUtils.forceMkdir(dbDirectory);
+        org.airsonic.player.util.FileUtils.copyResourcesRecursively(MetaDataFactoryTestCase.class.getResource("/db/pre-liquibase/db"), new File(homeParent));
+        
         someMp3 = temporaryFolder.newFile("some.mp3");
         someFlv = temporaryFolder.newFile("some.flv");
         someJunk = temporaryFolder.newFile("some.junk");
     }
-
-    @Rule
-    public final SpringMethodRule springMethodRule = new SpringMethodRule();
 
     @Autowired
     MetaDataParserFactory metaDataParserFactory;

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataFactoryTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataFactoryTestCase.java
@@ -1,15 +1,12 @@
 package org.airsonic.player.service.metadata;
 
-import org.airsonic.player.TestCaseUtils;
 import org.airsonic.player.service.SettingsService;
 import org.airsonic.player.util.HomeRule;
-import org.apache.commons.io.FileUtils;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.File;
@@ -20,7 +17,6 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class MetaDataFactoryTestCase {
 
     @ClassRule
@@ -35,12 +31,6 @@ public class MetaDataFactoryTestCase {
 
     @BeforeClass
     public static void createTestFiles() throws IOException {
-        String homeParent = TestCaseUtils.airsonicHomePathForTest();
-        
-        File dbDirectory = new File(homeParent, "/db");
-        FileUtils.forceMkdir(dbDirectory);
-        org.airsonic.player.util.FileUtils.copyResourcesRecursively(MetaDataFactoryTestCase.class.getResource("/db/pre-liquibase/db"), new File(homeParent));
-        
         someMp3 = temporaryFolder.newFile("some.mp3");
         someFlv = temporaryFolder.newFile("some.flv");
         someJunk = temporaryFolder.newFile("some.junk");

--- a/airsonic-main/src/test/java/org/airsonic/player/service/search/AbstractAirsonicHomeTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/search/AbstractAirsonicHomeTest.java
@@ -10,18 +10,17 @@ import org.airsonic.player.util.MusicFolderTestData;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
+@RunWith(SpringRunner.class)
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 /*
@@ -30,15 +29,7 @@ import java.util.function.Function;
 public abstract class AbstractAirsonicHomeTest implements AirsonicHomeTest {
 
     @ClassRule
-    public static final SpringClassRule classRule = new SpringClassRule() {
-        HomeRule homeRule = new HomeRule();
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-            Statement spring = super.apply(base, description);
-            return homeRule.apply(spring, description);
-        }
-    };
+    public static final HomeRule airsonicRule = new HomeRule();
 
     /*
      * Currently, Maven is executing test classes in series,
@@ -65,9 +56,6 @@ public abstract class AbstractAirsonicHomeTest implements AirsonicHomeTest {
 
     @Autowired
     protected SettingsService settingsService;
-
-    @Rule
-    public final SpringMethodRule springMethodRule = new SpringMethodRule();
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/airsonic-main/src/test/java/org/airsonic/player/service/search/QueryFactoryTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/search/QueryFactoryTestCase.java
@@ -8,15 +8,12 @@ import org.airsonic.player.util.HomeRule;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.lucene.search.Query;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,25 +28,15 @@ import static org.junit.Assert.assertEquals;
  * and observing the impact of upgrading Lucene.
  */
 
+@RunWith(SpringRunner.class)
 @SpringBootTest
 @DirtiesContext(
     classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class QueryFactoryTestCase {
 
     @ClassRule
-    public static final SpringClassRule classRule = new SpringClassRule() {
-        HomeRule homeRule = new HomeRule();
-
-        @Override
-        public Statement apply(Statement base, Description description) {
-            Statement spring = super.apply(base, description);
-            return homeRule.apply(spring, description);
-        }
-    };
-
-    @Rule
-    public final SpringMethodRule springMethodRule = new SpringMethodRule();
-
+    public static final HomeRule airsonicRule = new HomeRule();
+    
     @Autowired
     private QueryFactory queryFactory;
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/search/QueryFactoryTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/search/QueryFactoryTestCase.java
@@ -4,15 +4,12 @@ package org.airsonic.player.service.search;
 import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.domain.RandomSearchCriteria;
 import org.airsonic.player.domain.SearchCriteria;
-import org.airsonic.player.util.HomeRule;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.lucene.search.Query;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.File;
@@ -29,14 +26,9 @@ import static org.junit.Assert.assertEquals;
  */
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
-@DirtiesContext(
-    classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Import({ QueryFactory.class, AnalyzerFactory.class })
 public class QueryFactoryTestCase {
 
-    @ClassRule
-    public static final HomeRule airsonicRule = new HomeRule();
-    
     @Autowired
     private QueryFactory queryFactory;
 


### PR DESCRIPTION
This builds on #18, #21 and #22 and cleans up some tests to use the proper annotations and rules. This is necessary prior to upgrade because Spring Boot 2 does not allow the old test rules and the new to coexist.

This is Step 4 of a series of PRs each of which will build on each other

Next up: Move MVC Config out of Application and into Servlet

This is the same PR as https://github.com/airsonic/airsonic/pull/1369