### PR TITLE
Spring Boot 2 Upgrade: Part 5 - Move MVC Config to Servlet

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/Application.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/Application.java
@@ -1,7 +1,5 @@
 package org.airsonic.player;
 
-import org.airsonic.player.filter.*;
-import org.directwebremoting.servlet.DwrServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -10,13 +8,8 @@ import org.springframework.boot.autoconfigure.web.MultipartAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.boot.web.support.SpringBootServletInitializer;
-import org.springframework.context.annotation.Bean;
 import org.springframework.util.ReflectionUtils;
-
-import javax.servlet.Filter;
 
 import java.lang.reflect.Method;
 
@@ -27,132 +20,6 @@ import java.lang.reflect.Method;
 public class Application extends SpringBootServletInitializer implements EmbeddedServletContainerCustomizer {
 
     private static final Logger LOG = LoggerFactory.getLogger(Application.class);
-
-    /**
-     * Registers the DWR servlet.
-     *
-     * @return a registration bean.
-     */
-    @Bean
-    public ServletRegistrationBean dwrServletRegistrationBean() {
-        ServletRegistrationBean servlet = new ServletRegistrationBean(new DwrServlet(), "/dwr/*");
-        servlet.addInitParameter("crossDomainSessionSecurity","false");
-        return servlet;
-    }
-
-    @Bean
-    public ServletRegistrationBean cxfServletBean() {
-        return new ServletRegistrationBean(new org.apache.cxf.transport.servlet.CXFServlet(), "/ws/*");
-    }
-
-    @Bean
-    public FilterRegistrationBean bootstrapVerificationFilterRegistration() {
-        FilterRegistrationBean registration = new FilterRegistrationBean();
-        registration.setFilter(bootstrapVerificationFiler());
-        registration.addUrlPatterns("/*");
-        registration.setName("BootstrapVerificationFilter");
-        registration.setOrder(1);
-        return registration;
-    }
-
-    @Bean
-    public Filter bootstrapVerificationFiler() {
-        return new BootstrapVerificationFilter();
-    }
-
-    @Bean
-    public FilterRegistrationBean parameterDecodingFilterRegistration() {
-        FilterRegistrationBean registration = new FilterRegistrationBean();
-        registration.setFilter(parameterDecodingFilter());
-        registration.addUrlPatterns("/*");
-        registration.setName("ParameterDecodingFilter");
-        registration.setOrder(2);
-        return registration;
-    }
-
-    @Bean
-    public Filter parameterDecodingFilter() {
-        return new ParameterDecodingFilter();
-    }
-
-    @Bean
-    public FilterRegistrationBean restFilterRegistration() {
-        FilterRegistrationBean registration = new FilterRegistrationBean();
-        registration.setFilter(restFilter());
-        registration.addUrlPatterns("/rest/*");
-        registration.setName("RESTFilter");
-        registration.setOrder(3);
-        return registration;
-    }
-
-    @Bean
-    public Filter restFilter() {
-        return new RESTFilter();
-    }
-
-    @Bean
-    public FilterRegistrationBean requestEncodingFilterRegistration() {
-        FilterRegistrationBean registration = new FilterRegistrationBean();
-        registration.setFilter(requestEncodingFilter());
-        registration.addUrlPatterns("/*");
-        registration.addInitParameter("encoding", "UTF-8");
-        registration.setName("RequestEncodingFilter");
-        registration.setOrder(4);
-        return registration;
-    }
-
-    @Bean
-    public Filter requestEncodingFilter() {
-        return new RequestEncodingFilter();
-    }
-
-    @Bean
-    public FilterRegistrationBean cacheFilterRegistration() {
-        FilterRegistrationBean registration = new FilterRegistrationBean();
-        registration.setFilter(cacheFilter());
-        registration.addUrlPatterns("/icons/*", "/style/*", "/script/*", "/dwr/*", "/icons/*", "/coverArt.view", "/avatar.view");
-        registration.addInitParameter("Cache-Control", "max-age=36000");
-        registration.setName("CacheFilter");
-        registration.setOrder(5);
-        return registration;
-    }
-
-    @Bean
-    public Filter cacheFilter() {
-        return new ResponseHeaderFilter();
-    }
-
-    @Bean
-    public FilterRegistrationBean noCacheFilterRegistration() {
-        FilterRegistrationBean registration = new FilterRegistrationBean();
-        registration.setFilter(noCacheFilter());
-        registration.addUrlPatterns("/statusChart.view", "/userChart.view", "/playQueue.view", "/podcastChannels.view", "/podcastChannel.view", "/help.view", "/top.view", "/home.view");
-        registration.addInitParameter("Cache-Control", "no-cache, post-check=0, pre-check=0");
-        registration.addInitParameter("Pragma", "no-cache");
-        registration.addInitParameter("Expires", "Thu, 01 Dec 1994 16:00:00 GMT");
-        registration.setName("NoCacheFilter");
-        registration.setOrder(6);
-        return registration;
-    }
-
-    @Bean
-    public Filter metricsFilter() {
-        return new MetricsFilter();
-    }
-
-    @Bean
-    public FilterRegistrationBean metricsFilterRegistration() {
-        FilterRegistrationBean registration = new FilterRegistrationBean();
-        registration.setFilter(metricsFilter());
-        registration.setOrder(7);
-        return registration;
-    }
-
-
-    @Bean
-    public Filter noCacheFilter() {
-        return new ResponseHeaderFilter();
-    }
 
     private static SpringApplicationBuilder doConfigure(SpringApplicationBuilder application) {
         // Customize the application or call application.sources(...) to add sources

--- a/airsonic-main/src/main/java/org/airsonic/player/spring/ServletConfiguration.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/spring/ServletConfiguration.java
@@ -1,6 +1,15 @@
 package org.airsonic.player.spring;
 
 import org.airsonic.player.controller.PodcastController;
+import org.airsonic.player.filter.BootstrapVerificationFilter;
+import org.airsonic.player.filter.MetricsFilter;
+import org.airsonic.player.filter.ParameterDecodingFilter;
+import org.airsonic.player.filter.RESTFilter;
+import org.airsonic.player.filter.RequestEncodingFilter;
+import org.airsonic.player.filter.ResponseHeaderFilter;
+import org.directwebremoting.servlet.DwrServlet;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.ViewResolver;
@@ -11,11 +20,139 @@ import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.JstlView;
 
+import javax.servlet.Filter;
+
 import java.util.Properties;
 
 @Configuration
 @EnableWebMvc
 public class ServletConfiguration extends WebMvcConfigurerAdapter {
+    /**
+     * Registers the DWR servlet.
+     *
+     * @return a registration bean.
+     */
+    @Bean
+    public ServletRegistrationBean dwrServletRegistrationBean() {
+        ServletRegistrationBean servlet = new ServletRegistrationBean(new DwrServlet(), "/dwr/*");
+        servlet.addInitParameter("crossDomainSessionSecurity","false");
+        return servlet;
+    }
+
+    @Bean
+    public ServletRegistrationBean cxfServletBean() {
+        return new ServletRegistrationBean(new org.apache.cxf.transport.servlet.CXFServlet(), "/ws/*");
+    }
+
+    @Bean
+    public FilterRegistrationBean bootstrapVerificationFilterRegistration() {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(bootstrapVerificationFiler());
+        registration.addUrlPatterns("/*");
+        registration.setName("BootstrapVerificationFilter");
+        registration.setOrder(1);
+        return registration;
+    }
+
+    @Bean
+    public Filter bootstrapVerificationFiler() {
+        return new BootstrapVerificationFilter();
+    }
+
+    @Bean
+    public FilterRegistrationBean parameterDecodingFilterRegistration() {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(parameterDecodingFilter());
+        registration.addUrlPatterns("/*");
+        registration.setName("ParameterDecodingFilter");
+        registration.setOrder(2);
+        return registration;
+    }
+
+    @Bean
+    public Filter parameterDecodingFilter() {
+        return new ParameterDecodingFilter();
+    }
+
+    @Bean
+    public FilterRegistrationBean restFilterRegistration() {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(restFilter());
+        registration.addUrlPatterns("/rest/*");
+        registration.setName("RESTFilter");
+        registration.setOrder(3);
+        return registration;
+    }
+
+    @Bean
+    public Filter restFilter() {
+        return new RESTFilter();
+    }
+
+    @Bean
+    public FilterRegistrationBean requestEncodingFilterRegistration() {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(requestEncodingFilter());
+        registration.addUrlPatterns("/*");
+        registration.addInitParameter("encoding", "UTF-8");
+        registration.setName("RequestEncodingFilter");
+        registration.setOrder(4);
+        return registration;
+    }
+
+    @Bean
+    public Filter requestEncodingFilter() {
+        return new RequestEncodingFilter();
+    }
+
+    @Bean
+    public FilterRegistrationBean cacheFilterRegistration() {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(cacheFilter());
+        registration.addUrlPatterns("/icons/*", "/style/*", "/script/*", "/dwr/*", "/icons/*", "/coverArt.view", "/avatar.view");
+        registration.addInitParameter("Cache-Control", "max-age=36000");
+        registration.setName("CacheFilter");
+        registration.setOrder(5);
+        return registration;
+    }
+
+    @Bean
+    public Filter cacheFilter() {
+        return new ResponseHeaderFilter();
+    }
+
+    @Bean
+    public FilterRegistrationBean noCacheFilterRegistration() {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(noCacheFilter());
+        registration.addUrlPatterns("/statusChart.view", "/userChart.view", "/playQueue.view", "/podcastChannels.view", "/podcastChannel.view", "/help.view", "/top.view", "/home.view");
+        registration.addInitParameter("Cache-Control", "no-cache, post-check=0, pre-check=0");
+        registration.addInitParameter("Pragma", "no-cache");
+        registration.addInitParameter("Expires", "Thu, 01 Dec 1994 16:00:00 GMT");
+        registration.setName("NoCacheFilter");
+        registration.setOrder(6);
+        return registration;
+    }
+
+    @Bean
+    public Filter metricsFilter() {
+        return new MetricsFilter();
+    }
+
+    @Bean
+    public FilterRegistrationBean metricsFilterRegistration() {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(metricsFilter());
+        registration.setOrder(7);
+        return registration;
+    }
+
+
+    @Bean
+    public Filter noCacheFilter() {
+        return new ResponseHeaderFilter();
+    }
+    
     @Bean
     public ViewResolver viewResolver() {
         InternalResourceViewResolver resolver = new InternalResourceViewResolver();


### PR DESCRIPTION
This builds on #18, #21, #22 and #23 and moves MVC Config to Servlet.java instead of littering the root Application.java. This is a purely cosmetic change so that churn in Application.java is reduced. It confers benefits in the future for slicing tests, which don't need to have heavy bindings in the root context.

This is Step 5 of a series of PRs each of which will build on each other

Next up: Spring Boot 2 and dependency upgrades

This is the same PR as https://github.com/airsonic/airsonic/pull/1370