### PR TITLE
Fix retrieval of versions from airsonic-advanced repo instead of airsonic and get release tags from build info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,11 +49,11 @@ matrix:
         if ! [ "$BEFORE_DEPLOY_RUN" ]; then
           export BEFORE_DEPLOY_RUN=1;
           # Create tag
-          ver=$(grep "version=" airsonic-main/target/generated/build-metadata/build.properties | cut -d"=" -f2)
-          ts=$(grep "timestamp=" airsonic-main/target/generated/build-metadata/build.properties | cut -d"=" -f2)
+          ver=$(grep "version=" airsonic-main/target/generated/build-metadata/build.properties | cut -d"=" -f2);
+          ts=$(grep "timestamp=" airsonic-main/target/generated/build-metadata/build.properties | cut -d"=" -f2);
           # Note this doesn't completely follow semver because docker tags do not take a + sign
-          export TRAVIS_TAG=${TRAVIS_TAG:-$ver\.$ts}
-          echo $TRAVIS_TAG
+          export TRAVIS_TAG=${TRAVIS_TAG:-$ver\.$ts};
+          echo $TRAVIS_TAG;
           
           # Tag the docker image
           docker tag airsonicadvanced/airsonic-advanced:latest airsonicadvanced/airsonic-advanced:edge-$TRAVIS_TAG;

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,17 +42,18 @@ matrix:
   - name: "Deploy Edge Release"
     stage: deploy_edge
     jdk: openjdk8
-    before_script:
-      - export PROJECT_MAVEN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-      # Note this doesn't completely follow semver because docker tags do not take a + sign
-      - export TRAVIS_TAG=${TRAVIS_TAG:-$PROJECT_MAVEN_VERSION.$(date +'%Y%m%d%H%M%S')}
-      - echo $TRAVIS_TAG
     script:
       - mvn package -P docker -DskipTests
     before_deploy:
       - >
         if ! [ "$BEFORE_DEPLOY_RUN" ]; then
           export BEFORE_DEPLOY_RUN=1;
+          # Create tag
+          ver=$(grep "version=" airsonic-main/target/generated/build-metadata/build.properties | cut -d"=" -f2)
+          ts=$(grep "timestamp=" airsonic-main/target/generated/build-metadata/build.properties | cut -d"=" -f2)
+          # Note this doesn't completely follow semver because docker tags do not take a + sign
+          export TRAVIS_TAG=${TRAVIS_TAG:-$ver\.$ts}
+          echo $TRAVIS_TAG
           
           # Tag the docker image
           docker tag airsonicadvanced/airsonic-advanced:latest airsonicadvanced/airsonic-advanced:edge-$TRAVIS_TAG;

--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -520,10 +520,6 @@
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.jayway.jsonpath</groupId>
-            <artifactId>json-path</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
             <scope>runtime</scope>
@@ -622,23 +618,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>buildnumber-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>create</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <doCheck>false</doCheck>
-                    <doUpdate>false</doUpdate>
-                    <revisionOnScmFailure>Unversioned</revisionOnScmFailure>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
@@ -646,13 +625,8 @@
                         <phase>generate-resources</phase>
                         <configuration>
                             <target>
-                                <tstamp/>
                                 <copy file="${basedir}/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties"
                                       tofile="${project.build.directory}/classes/org/airsonic/player/i18n/ResourceBundle.properties"/>
-                                <echo file="${project.build.directory}/classes/build_number.txt">${buildNumber}</echo>
-                                <!--suppress MavenModelInspection -->
-                                <echo file="${project.build.directory}/classes/build_date.txt">${DSTAMP}</echo>
-                                <echo file="${project.build.directory}/classes/version.txt">${project.version}</echo>
                             </target>
                         </configuration>
                         <goals>
@@ -660,6 +634,25 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>buildnumber-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <phase>generate-resources</phase>
+                  <goals>
+                    <goal>create-metadata</goal>
+                  </goals>
+                </execution>
+              </executions>
+              <configuration>
+                <timezone>UTC</timezone>
+                <timestampFormat>yyyyMMddHHmmss</timestampFormat>
+                <attach>true</attach>
+                <!--make it available for jar/war classpath resource -->
+                <addOutputDirectoryToResources>true</addOutputDirectoryToResources>
+              </configuration>
             </plugin>
             <plugin>
                 <groupId>org.owasp</groupId>

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Version.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Version.java
@@ -19,6 +19,10 @@
  */
 package org.airsonic.player.domain;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
@@ -31,6 +35,12 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
  */
 public class Version implements Comparable<Version> {
     private final DefaultArtifactVersion internalVersion;
+    private String commit;
+    private Boolean preview;
+    private String url;
+    private Instant publishDate;
+    private Instant releaseCreateDate;
+    private List<Map<String,Object>> artifacts;
 
     /**
      * Creates a new version instance by parsing the given string.
@@ -40,7 +50,18 @@ public class Version implements Comparable<Version> {
         this.internalVersion = new DefaultArtifactVersion(version);
     }
 
-    public int getMajor() {
+    public Version(String version, String commit, Boolean preview, String url,
+			Instant publishDate, Instant releaseCreateDate, List<Map<String, Object>> artifacts) {
+		this(version);
+		this.commit = commit;
+		this.preview = preview;
+		this.url = url;
+		this.publishDate = publishDate;
+		this.releaseCreateDate = releaseCreateDate;
+		this.artifacts = artifacts;
+	}
+
+	public int getMajor() {
         return internalVersion.getMajorVersion();
     }
 
@@ -77,7 +98,31 @@ public class Version implements Comparable<Version> {
         return internalVersion.toString();
     }
 
-    /**
+    public String getCommit() {
+		return commit;
+	}
+
+	public Boolean getPreview() {
+		return preview;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public Instant getPublishDate() {
+		return publishDate;
+	}
+
+	public Instant getReleaseCreateDate() {
+		return releaseCreateDate;
+	}
+
+	public List<Map<String, Object>> getArtifacts() {
+		return artifacts;
+	}
+
+	/**
      * Compares this object with the specified object for order.
      * @param version The object to compare to.
      * @return A negative integer, zero, or a positive integer as this object is less than, equal to, or

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/Version.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/Version.java
@@ -19,13 +19,13 @@
  */
 package org.airsonic.player.domain;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Represents the version number of Airsonic.
@@ -51,17 +51,17 @@ public class Version implements Comparable<Version> {
     }
 
     public Version(String version, String commit, Boolean preview, String url,
-			Instant publishDate, Instant releaseCreateDate, List<Map<String, Object>> artifacts) {
-		this(version);
-		this.commit = commit;
-		this.preview = preview;
-		this.url = url;
-		this.publishDate = publishDate;
-		this.releaseCreateDate = releaseCreateDate;
-		this.artifacts = artifacts;
-	}
+            Instant publishDate, Instant releaseCreateDate, List<Map<String, Object>> artifacts) {
+        this(version);
+        this.commit = commit;
+        this.preview = preview;
+        this.url = url;
+        this.publishDate = publishDate;
+        this.releaseCreateDate = releaseCreateDate;
+        this.artifacts = artifacts;
+    }
 
-	public int getMajor() {
+    public int getMajor() {
         return internalVersion.getMajorVersion();
     }
 
@@ -99,30 +99,30 @@ public class Version implements Comparable<Version> {
     }
 
     public String getCommit() {
-		return commit;
-	}
+        return commit;
+    }
 
-	public Boolean getPreview() {
-		return preview;
-	}
+    public Boolean getPreview() {
+        return preview;
+    }
 
-	public String getUrl() {
-		return url;
-	}
+    public String getUrl() {
+        return url;
+    }
 
-	public Instant getPublishDate() {
-		return publishDate;
-	}
+    public Instant getPublishDate() {
+        return publishDate;
+    }
 
-	public Instant getReleaseCreateDate() {
-		return releaseCreateDate;
-	}
+    public Instant getReleaseCreateDate() {
+        return releaseCreateDate;
+    }
 
-	public List<Map<String, Object>> getArtifacts() {
-		return artifacts;
-	}
+    public List<Map<String, Object>> getArtifacts() {
+        return artifacts;
+    }
 
-	/**
+    /**
      * Compares this object with the specified object for order.
      * @param version The object to compare to.
      * @return A negative integer, zero, or a positive integer as this object is less than, equal to, or

--- a/airsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
@@ -69,7 +69,7 @@ public class VersionService {
     private String localBuildNumber;
     
     public VersionService() throws IOException {
-    	build = PropertiesLoaderUtils.loadAllProperties("build.properties");
+        build = PropertiesLoaderUtils.loadAllProperties("build.properties");
     }
 
     /**
@@ -208,25 +208,25 @@ public class VersionService {
     private static final String VERSION_URL = "https://api.github.com/repos/airsonic-advanced/airsonic-advanced/releases";
 
     private static ResponseHandler<List<Map<String, Object>>> respHandler = new AbstractResponseHandler<List<Map<String,Object>>>() {
-		@Override
-		public List<Map<String, Object>> handleEntity(HttpEntity entity) throws IOException {
-			try (InputStream is = entity.getContent(); InputStream bis = new BufferedInputStream(is)) {
-				return Util.getObjectMapper().readValue(bis, new TypeReference<List<Map<String, Object>>>() {});
-			}
-		}
-	};
-	
-	private static Function<Map<String,Object>, Version> releaseToVersionMapper = r -> 
-			new Version(
-					(String) r.get("tag_name"), 
-					(String) r.get("target_commitish"), 
-					(Boolean) r.get("draft") || (Boolean) r.get("prerelease"),
-					(String) r.get("html_url"),
-					Instant.parse((String) r.get("published_at")),
-					Instant.parse((String) r.get("created_at")),
-					(List<Map<String,Object>>) r.get("assets")
-					);
-	
+        @Override
+        public List<Map<String, Object>> handleEntity(HttpEntity entity) throws IOException {
+            try (InputStream is = entity.getContent(); InputStream bis = new BufferedInputStream(is)) {
+                return Util.getObjectMapper().readValue(bis, new TypeReference<List<Map<String, Object>>>() {});
+            }
+        }
+    };
+    
+    private static Function<Map<String,Object>, Version> releaseToVersionMapper = r -> 
+            new Version(
+                    (String) r.get("tag_name"), 
+                    (String) r.get("target_commitish"), 
+                    (Boolean) r.get("draft") || (Boolean) r.get("prerelease"),
+                    (String) r.get("html_url"),
+                    Instant.parse((String) r.get("published_at")),
+                    Instant.parse((String) r.get("created_at")),
+                    (List<Map<String,Object>>) r.get("assets")
+                    );
+    
     /**
      * Resolves the latest available Airsonic version by inspecting github.
      */
@@ -248,8 +248,8 @@ public class VersionService {
         }
         
         List<Map<String, Object>> releases = content.stream()
-        		.sorted(Comparator.<Map<String, Object>,Instant>comparing(r -> Instant.parse((String) r.get("published_at")), Comparator.reverseOrder()))
-        		.collect(Collectors.toList());
+                .sorted(Comparator.<Map<String, Object>,Instant>comparing(r -> Instant.parse((String) r.get("published_at")), Comparator.reverseOrder()))
+                .collect(Collectors.toList());
 
 
         Optional<Map<String, Object>> betaR = releases.stream().findFirst();

--- a/airsonic-main/src/main/java/org/airsonic/player/util/Util.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/Util.java
@@ -126,7 +126,7 @@ public final class Util {
             .configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
     
     public static ObjectMapper getObjectMapper() {
-    	return objectMapper;
+        return objectMapper;
     }
 
     public static String debugObject(Object object) {

--- a/airsonic-main/src/main/java/org/airsonic/player/util/Util.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/Util.java
@@ -124,6 +124,10 @@ public final class Util {
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
             .configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
+    
+    public static ObjectMapper getObjectMapper() {
+    	return objectMapper;
+    }
 
     public static String debugObject(Object object) {
         try {


### PR DESCRIPTION
- Generate build info and store it in a file at build time
- Get release tag for docker and github releases from build info generated
- Retrieve build info during runtime
- Retrieve version updates from the correct repo (airsonic-advanced)