### PR TITLE
Batch updates with a specified row liimit

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/command/DatabaseSettingsCommand.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/command/DatabaseSettingsCommand.java
@@ -15,6 +15,7 @@ public class DatabaseSettingsCommand {
     private String JNDIName;
     private int mysqlVarcharMaxlength;
     private String usertableQuote;
+    private int rowUpdateLimit;
 
     public DataSourceConfigType getConfigType() {
         return configType;
@@ -78,5 +79,13 @@ public class DatabaseSettingsCommand {
 
     public void setUsertableQuote(String usertableQuote) {
         this.usertableQuote = usertableQuote;
+    }
+
+    public int getRowUpdateLimit() {
+        return rowUpdateLimit;
+    }
+
+    public void setRowUpdateLimit(int rowUpdateLimit) {
+        this.rowUpdateLimit = rowUpdateLimit;
     }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DatabaseSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DatabaseSettingsController.java
@@ -56,6 +56,7 @@ public class DatabaseSettingsController {
         command.setJNDIName(settingsService.getDatabaseConfigJNDIName());
         command.setMysqlVarcharMaxlength(settingsService.getDatabaseMysqlVarcharMaxlength());
         command.setUsertableQuote(settingsService.getDatabaseUsertableQuote());
+        command.setRowUpdateLimit(settingsService.getDatabaseUpdateRowLimit());
         model.addAttribute("command", command);
     }
 
@@ -84,6 +85,7 @@ public class DatabaseSettingsController {
                 settingsService.setDatabaseMysqlVarcharMaxlength(command.getMysqlVarcharMaxlength());
                 settingsService.setDatabaseUsertableQuote(command.getUsertableQuote());
             }
+            settingsService.setDatabaseUpdateRowLimit(command.getRowUpdateLimit());
             redirectAttributes.addFlashAttribute("settings_toast", true);
             settingsService.save();
             return "redirect:databaseSettings.view";

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/AlbumDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/AlbumDao.java
@@ -346,7 +346,7 @@ public class AlbumDao extends AbstractDao {
         } else {
             // incremental updates to ensure no table locks for extended time and deals with cases where id range isn't contiguous
             String sql = "update album set present=false where id in (select id from album where last_scanned < ? and present order by id limit " + settingsService.getDatabaseUpdateRowLimit() + ")";
-            while (update(sql, lastScanned) > 0) {}
+            while (update(sql, lastScanned) > 0) { }
         }
     }
 
@@ -360,7 +360,7 @@ public class AlbumDao extends AbstractDao {
         } else {
             // incremental updates to ensure no table locks for extended time and deals with cases where id range isn't contiguous
             String sql = "delete from album where id in (select id from album where not present order by id limit " + settingsService.getDatabaseUpdateRowLimit() + ")";
-            while (update(sql) > 0) {}
+            while (update(sql) > 0) { }
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/ArtistDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/ArtistDao.java
@@ -171,7 +171,7 @@ public class ArtistDao extends AbstractDao {
         } else {
             // incremental updates to ensure no table locks for extended time and deals with cases where id range isn't contiguous
             String sql = "update artist set present=false where id in (select id from artist where last_scanned < ? and present order by id limit " + settingsService.getDatabaseUpdateRowLimit() + ")";
-            while (update(sql, lastScanned) > 0) {}
+            while (update(sql, lastScanned) > 0) { }
         }
     }
 
@@ -185,7 +185,7 @@ public class ArtistDao extends AbstractDao {
         } else {
             // incremental updates to ensure no table locks for extended time and deals with cases where id range isn't contiguous
             String sql = "delete from artist where id in (select id from artist where not present order by id limit " + settingsService.getDatabaseUpdateRowLimit() + ")";
-            while (update(sql) > 0) {}
+            while (update(sql) > 0) { }
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/ArtistDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/ArtistDao.java
@@ -21,6 +21,8 @@ package org.airsonic.player.dao;
 
 import org.airsonic.player.domain.Artist;
 import org.airsonic.player.domain.MusicFolder;
+import org.airsonic.player.service.SettingsService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +42,9 @@ public class ArtistDao extends AbstractDao {
     private static final String INSERT_COLUMNS = "name, cover_art_path, album_count, last_scanned, present, folder_id";
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
 
+    @Autowired
+    private SettingsService settingsService;
+    
     private final RowMapper rowMapper = new ArtistMapper();
 
     /**
@@ -161,7 +166,13 @@ public class ArtistDao extends AbstractDao {
     }
 
     public void markNonPresent(Instant lastScanned) {
-        update("update artist set present=false where last_scanned < ? and present", lastScanned);
+        if (settingsService.getDatabaseUpdateRowLimit() <= 0) {
+            update("update artist set present=false where last_scanned < ? and present", lastScanned);
+        } else {
+            // incremental updates to ensure no table locks for extended time and deals with cases where id range isn't contiguous
+            String sql = "update artist set present=false where id in (select id from artist where last_scanned < ? and present order by id limit " + settingsService.getDatabaseUpdateRowLimit() + ")";
+            while (update(sql, lastScanned) > 0) {}
+        }
     }
 
     public List<Integer> getExpungeCandidates() {
@@ -169,7 +180,13 @@ public class ArtistDao extends AbstractDao {
     }
 
     public void expunge() {
-        update("delete from artist where not present");
+        if (settingsService.getDatabaseUpdateRowLimit() <= 0) {
+            update("delete from artist where not present");
+        } else {
+            // incremental updates to ensure no table locks for extended time and deals with cases where id range isn't contiguous
+            String sql = "delete from artist where id in (select id from artist where not present order by id limit " + settingsService.getDatabaseUpdateRowLimit() + ")";
+            while (update(sql) > 0) {}
+        }
     }
 
     public void starArtist(int artistId, String username) {

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
@@ -678,7 +678,7 @@ public class MediaFileDao extends AbstractDao {
         } else {
             // incremental updates to ensure no table locks for extended time and deals with cases where id range isn't contiguous
             String sql = "update media_file set present=false, children_last_updated=? where id in (select id from media_file where last_scanned < ? and present order by id limit " + settingsService.getDatabaseUpdateRowLimit() + ")";
-            while (update(sql, childrenLastUpdated, lastScanned) > 0) {}
+            while (update(sql, childrenLastUpdated, lastScanned) > 0) { }
         }
         
     }
@@ -705,7 +705,7 @@ public class MediaFileDao extends AbstractDao {
         } else {
             // incremental updates to ensure no table locks for extended time and deals with cases where id range isn't contiguous
             String sql = "delete from media_file where id in (select id from media_file where not present order by id limit " + settingsService.getDatabaseUpdateRowLimit() + ")";
-            while (update(sql) > 0) {}
+            while (update(sql) > 0) { }
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -134,6 +134,7 @@ public class SettingsService {
     private static final String KEY_DATABASE_CONFIG_JNDI_NAME = "DatabaseConfigJNDIName";
     private static final String KEY_DATABASE_MYSQL_VARCHAR_MAXLENGTH = "DatabaseMysqlMaxlength";
     private static final String KEY_DATABASE_USERTABLE_QUOTE = "DatabaseUsertableQuote";
+    private static final String KEY_DATABASE_UPDATE_ROW_LIMIT = "DatabaseUpdateRowLimit";
 
     // Default values.
     private static final String DEFAULT_JWT_KEY = null;
@@ -1405,6 +1406,14 @@ public class SettingsService {
 
     public void setDatabaseUsertableQuote(String usertableQuote) {
         setString(KEY_DATABASE_USERTABLE_QUOTE, usertableQuote);
+    }
+    
+    public void setDatabaseUpdateRowLimit(int limit) {
+        setInt(KEY_DATABASE_UPDATE_ROW_LIMIT, limit);
+    }
+    
+    public int getDatabaseUpdateRowLimit() {
+        return getInt(KEY_DATABASE_UPDATE_ROW_LIMIT, 0);
     }
 
     public String getJWTKey() {

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
@@ -533,6 +533,7 @@ databasesettings.embeddriver=JDBC driver for Java classname
 databasesettings.embedurl=JDBC URL
 databasesettings.embedusername=JDBC Username
 databasesettings.embedpassword=JDBC Password
+databasesettings.rowupdatelimit=Row Update Limit
 databasettings.restartRequired=Changes to database settings require a restart to take effect.
 
 main.up=Up
@@ -658,6 +659,8 @@ helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.embeddriver.title=JDBC Driver Class
 helppopup.embeddriver.text=JDBC Driver dependent class name that implments java.sql.Driver. I.e. for PostgreSQL one would use org.postgresql.Driver. This class must be present in the classpath.
+helppopup.rowupdatelimit.title=Row Update Limit
+helppopup.rowupdatelimit.text=If set to 0 or below, will attempt to update DB in one go. Otherwise will try updating DB in batches so the tables don't stay locked for an extended period of time by one thread. 0 or negative value disables batching (batch size is infinite), otherwise, generally a smaller value will lock tables the shortest (allowing other queries to go through between batches), but will overall take the longest to complete as a whole. You should aim to set this as high as possible while not suffering a performance penalty. Most small to medium/large DBs will want this off
 helppopup.excludepattern.title=Exclude Pattern
 helppopup.excludepattern.text=Airsonic will not import any files matching this regular expression pattern.
 helppopup.playlistfolder.title=Import playlist from

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/databaseSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/databaseSettings.jsp
@@ -37,6 +37,18 @@
 
 <form:form modelAttribute="command" action="databaseSettings.view" method="post">
     <p><fmt:message key="databasesettings.moreinfo"/></p>
+    
+    <div>
+        <table style="white-space:nowrap" class="indent">
+            <tr>
+                <td><fmt:message key="databasesettings.rowupdatelimit"/></td>
+                <td>
+                    <form:input path="rowUpdateLimit" size="8"/>
+                    <c:import url="helpToolTip.jsp"><c:param name="topic" value="rowupdatelimit"/></c:import>
+                </td>
+            </tr>
+        </table>
+    </div>
 
     <table style="white-space:nowrap" class="indent">
         <tr>


### PR DESCRIPTION
Successor to https://github.com/airsonic-advanced/airsonic-advanced/pull/28 per discussion in that PR thread.

Exposes a custom specifiable db update row limit that may be used to control how the db is updated.

A value of 0 or below turns off the batching
A non negative, non zero value updates the db in batches of that size.

Higher value will attempt to update more rows in one roundtrip (thus requiring less roundtrips overall), but might lock the table for longer for each trip.
Lower value will update less rows in one roundtrip, thus locking the table continuously for a shorter amount of time, but will require more trips to the DB.
Zero or below will turn off batching and system will attempt to update everything in one go.

Intended for play and match per size/type/traffic of DB and system.


