### PR TITLE
Add last scanned indices for tables that use them

### DIFF
--- a/airsonic-main/src/main/resources/liquibase/10.6/add-lastscanned-indices.xml
+++ b/airsonic-main/src/main/resources/liquibase/10.6/add-lastscanned-indices.xml
@@ -1,0 +1,35 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="album-lastscanned-index" author="anonymous">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="idx_album_last_scanned" />
+            </not>
+        </preConditions>
+        <createIndex tableName="album" indexName="idx_album_last_scanned">
+            <column name="last_scanned" />
+        </createIndex>
+    </changeSet>
+    <changeSet id="artist-lastscanned-index" author="anonymous">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="idx_artist_last_scanned" />
+            </not>
+        </preConditions>
+        <createIndex tableName="artist" indexName="idx_artist_last_scanned">
+            <column name="last_scanned" />
+        </createIndex>
+    </changeSet>
+    <changeSet id="mediafile-lastscanned-index" author="anonymous">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="idx_media_file_last_scanned" />
+            </not>
+        </preConditions>
+        <createIndex tableName="media_file" indexName="idx_media_file_last_scanned">
+            <column name="last_scanned" />
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/10.6/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/10.6/changelog.xml
@@ -1,0 +1,6 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <include file="add-lastscanned-indices.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -12,4 +12,5 @@
     <include file="6.3/changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.4/changelog.xml" relativeToChangelogFile="true"/>
     <include file="10.2/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="10.6/changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
Several queries for artists, albums and media files are using last_scanned to query rows particularly when marking nonpresent entities or when expunging. This index should technically help for bigger dbs so the index is a factor in the query planner's arsenal.