### PR TITLE
Migrate properties automatically

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/Application.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/Application.java
@@ -1,5 +1,6 @@
 package org.airsonic.player;
 
+import org.airsonic.player.service.SettingsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.WebApplicationType;
@@ -7,9 +8,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.MultipartAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.event.ApplicationContextInitializedEvent;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.context.ApplicationListener;
 import org.springframework.util.ReflectionUtils;
 
 import java.lang.reflect.Method;
@@ -23,6 +26,11 @@ public class Application extends SpringBootServletInitializer implements WebServ
     private static final Logger LOG = LoggerFactory.getLogger(Application.class);
 
     private static SpringApplicationBuilder doConfigure(SpringApplicationBuilder application) {
+        application.application().addListeners((ApplicationListener<ApplicationContextInitializedEvent>) event -> {
+            // Migrate keys to the latest
+            SettingsService.migrateKeys();
+        });
+
         // Customize the application or call application.sources(...) to add sources
         // Since our example is itself a @Configuration class (via @SpringBootApplication)
         // we actually don't need to override this method.

--- a/airsonic-main/src/test/java/org/airsonic/player/service/SettingsServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/SettingsServiceTestCase.java
@@ -32,7 +32,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -154,5 +156,107 @@ public class SettingsServiceTestCase {
         assertEquals("Wrong LDAP manager password.", "secret", settingsService.getLdapManagerPassword());
         assertEquals("Wrong LDAP search filter.", "newLdapSearchFilter", settingsService.getLdapSearchFilter());
         assertTrue("Wrong LDAP auto-shadowing.", settingsService.isLdapAutoShadowing());
+    }
+
+    @Test
+    public void migrateKeys_noKeys() {
+        Map<String, String> keyMaps = new LinkedHashMap<>();
+        keyMaps.put("bla", "bla2");
+        keyMaps.put("bla2", "bla3");
+        SettingsService.migrateKeys(keyMaps);
+
+        assertNull(env.getProperty("bla"));
+        assertNull(env.getProperty("bla2"));
+        assertNull(env.getProperty("bla3"));
+    }
+
+    @Test
+    public void migrateKeys_deleteKeys_BackwardsCompatibilitySet() {
+        ConfigurationPropertiesService.getInstance().setProperty("bla", "hello");
+
+        Map<String, String> keyMaps = new LinkedHashMap<>();
+        keyMaps.put("bla", "bla2");
+        keyMaps.put("bla2", "bla3");
+        keyMaps.put("bla3", null);
+        SettingsService.migrateKeys(keyMaps);
+
+        assertEquals("hello", env.getProperty("bla"));
+        assertEquals("hello", env.getProperty("bla2"));
+        assertNull(env.getProperty("bla3"));
+    }
+
+    @Test
+    public void migrateKeys_deleteKeys_NonBackwardsCompatible() {
+        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_UPGRADE_RETAIN_COMPATIBILITY, "false");
+        ConfigurationPropertiesService.getInstance().setProperty("bla", "hello");
+
+        Map<String, String> keyMaps = new LinkedHashMap<>();
+        keyMaps.put("bla", "bla2");
+        keyMaps.put("bla2", "bla3");
+        keyMaps.put("bla3", null);
+        SettingsService.migrateKeys(keyMaps);
+
+        assertNull(env.getProperty("bla"));
+        assertNull(env.getProperty("bla2"));
+        assertNull(env.getProperty("bla3"));
+    }
+
+    @Test
+    public void migrateKeys_withKeys_ExplicitlyBackwardsCompatible() {
+        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_UPGRADE_RETAIN_COMPATIBILITY, "true");
+        ConfigurationPropertiesService.getInstance().setProperty("bla", "hello");
+        ConfigurationPropertiesService.getInstance().setProperty("bla3", "hello2");
+
+        Map<String, String> keyMaps = new LinkedHashMap<>();
+        keyMaps.put("bla", "bla2");
+        keyMaps.put("bla2", "bla3");
+        keyMaps.put("bla3", "bla4");
+        keyMaps.put("bla4", "bla5");
+        SettingsService.migrateKeys(keyMaps);
+
+        assertEquals("hello", env.getProperty("bla"));
+        assertEquals("hello", env.getProperty("bla2"));
+        assertEquals("hello2", env.getProperty("bla3"));
+        assertEquals("hello2", env.getProperty("bla4"));
+        assertEquals("hello2", env.getProperty("bla5"));
+    }
+
+    @Test
+    public void migrateKeys_withKeys_ImplicitlyBackwardsCompatible() {
+        ConfigurationPropertiesService.getInstance().setProperty("bla", "hello");
+        ConfigurationPropertiesService.getInstance().setProperty("bla3", "hello2");
+
+        Map<String, String> keyMaps = new LinkedHashMap<>();
+        keyMaps.put("bla", "bla2");
+        keyMaps.put("bla2", "bla3");
+        keyMaps.put("bla3", "bla4");
+        keyMaps.put("bla4", "bla5");
+        SettingsService.migrateKeys(keyMaps);
+
+        assertEquals("hello", env.getProperty("bla"));
+        assertEquals("hello", env.getProperty("bla2"));
+        assertEquals("hello2", env.getProperty("bla3"));
+        assertEquals("hello2", env.getProperty("bla4"));
+        assertEquals("hello2", env.getProperty("bla5"));
+    }
+
+    @Test
+    public void migrateKeys_withKeys_NonBackwardsCompatible() {
+        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_UPGRADE_RETAIN_COMPATIBILITY, "false");
+        ConfigurationPropertiesService.getInstance().setProperty("bla", "hello");
+        ConfigurationPropertiesService.getInstance().setProperty("bla3", "hello2");
+
+        Map<String, String> keyMaps = new LinkedHashMap<>();
+        keyMaps.put("bla", "bla2");
+        keyMaps.put("bla2", "bla3");
+        keyMaps.put("bla3", "bla4");
+        keyMaps.put("bla4", "bla5");
+        SettingsService.migrateKeys(keyMaps);
+
+        assertNull(env.getProperty("bla"));
+        assertNull(env.getProperty("bla2"));
+        assertNull(env.getProperty("bla3"));
+        assertNull(env.getProperty("bla4"));
+        assertEquals("hello2", env.getProperty("bla5"));
     }
 }


### PR DESCRIPTION
Instead of removing obsolete property keys from the .properties file, migrate them to the new keys

Removal (what is currently done) is also possible if a particular key isn't used anymore at all.

This is done in preparation for major version upgrades, where key names are often renamed. In airsonic, this had to be done manually prior to upgrade. This PR allows airsonic to handle it automatically. In particular, database property names might change between airsonic-advanced and airsonic, and between airsonic 10 and 11. This PR should handle all the changes seamlessly.

Updates to the properties file (if needed) happens at Application startup. Obsolete keys do not need to be removed at every save point.

Property migration is handled as a chain, and as such order of migration is important (thus the use of LinkedHashMap as data structure to preserve intake iteration order):
- Say legacy `key1` was migrated to `key2` in 10.2, which was migrated to `key3` in 11.0
- The migrator will look at `key1` first to migrate to `key2`
- If `key1` has a value to migrate and `key2` does not already have a value (has been migrated before), the property is copied over.
- If backwards compatibility is set (default yes), the old `key1` is not deleted, which allows going back a version and still being able to use the old property. Otherwise `key1` is deleted.
- `key2` is then migrated to `key3` in the same manner
- At the end, if backwards compatibility is set to false, `key1` and `key2` don't exist and `key3` exists with `key1`'s value. If it's set to true, all 3 keys exist with the same value.

A key may be just removed also (non backwards compatible) by migrating it to null.

A new property determines that backwards-compatibility setting: `PropertiesFileUpgradeRetainCompatibility`
