### PR TITLE
Remove sync locks everywhere in StatusService and TransferStatus

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/TransferService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/TransferService.java
@@ -45,7 +45,7 @@ public class TransferService {
         TransferStatus status = (TransferStatus) session.getAttribute(UploadController.UPLOAD_STATUS);
 
         if (status != null) {
-            return new UploadInfo(status.getBytesTransfered(), status.getBytesTotal());
+            return new UploadInfo(status.getBytesTransferred(), status.getBytesTotal());
         }
         return new UploadInfo(0L, 0L);
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -148,7 +148,7 @@ public class DownloadController implements LastModified {
         } finally {
             if (status != null) {
                 statusService.removeDownloadStatus(status);
-                securityService.updateUserByteCounts(user, 0L, status.getBytesTransfered(), 0L);
+                securityService.updateUserByteCounts(user, 0L, status.getBytesTransferred(), 0L);
             }
         }
     }
@@ -282,12 +282,12 @@ public class DownloadController implements LastModified {
                 out.write(buf, 0, n);
 
                 // Don't sleep if outside range.
-                if (range != null && !range.contains(status.getBytesSkipped() + status.getBytesTransfered())) {
+                if (range != null && !range.contains(status.getBytesSkipped() + status.getBytesTransferred())) {
                     status.addBytesSkipped(n);
                     continue;
                 }
 
-                status.addBytesTransfered(n);
+                status.addBytesTransferred(n);
                 long after = System.currentTimeMillis();
 
                 // Calculate bitrate limit every 5 seconds.

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StatusController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StatusController.java
@@ -133,7 +133,7 @@ public class StatusController {
         }
 
         public String getBytes() {
-            return StringUtil.formatBytes(transferStatus.getBytesTransfered(), locale);
+            return StringUtil.formatBytes(transferStatus.getBytesTransferred(), locale);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -272,7 +272,7 @@ public class StreamController {
 
         } finally {
             if (status != null) {
-                securityService.updateUserByteCounts(user, status.getBytesTransfered(), 0L, 0L);
+                securityService.updateUserByteCounts(user, status.getBytesTransferred(), 0L, 0L);
                 statusService.removeStreamStatus(status);
             }
         }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/UploadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/UploadController.java
@@ -153,7 +153,7 @@ public class UploadController {
                 statusService.removeUploadStatus(status);
                 request.getSession().removeAttribute(UPLOAD_STATUS);
                 User user = securityService.getCurrentUser(request);
-                securityService.updateUserByteCounts(user, 0L, 0L, status.getBytesTransfered());
+                securityService.updateUserByteCounts(user, 0L, 0L, status.getBytesTransferred());
             }
         }
 
@@ -214,14 +214,14 @@ public class UploadController {
 
             // Throttle bitrate.
 
-            long byteCount = status.getBytesTransfered() + bytesRead;
+            long byteCount = status.getBytesTransferred() + bytesRead;
             long bitCount = byteCount * 8L;
 
             float elapsedMillis = Math.max(1, System.currentTimeMillis() - start);
             float elapsedSeconds = elapsedMillis / 1000.0F;
             long maxBitsPerSecond = getBitrateLimit();
 
-            status.setBytesTransfered(byteCount);
+            status.setBytesTransferred(byteCount);
 
             if (maxBitsPerSecond > 0) {
                 float sleepMillis = 1000.0F * (bitCount / maxBitsPerSecond - elapsedSeconds);

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/TransferStatus.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/TransferStatus.java
@@ -177,15 +177,6 @@ public class TransferStatus {
     }
 
     /**
-     * Sets the remote player for the stream.
-     *
-     * @param player The remote player for the stream.
-     */
-    public void setPlayer(Player player) {
-        this.player = player;
-    }
-
-    /**
      * Returns a history of samples for the stream
      *
      * @return A (copy of) the history list of samples.

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/TransferStatus.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/TransferStatus.java
@@ -34,14 +34,14 @@ public class TransferStatus {
     private static final int HISTORY_LENGTH = 200;
     private static final long SAMPLE_INTERVAL_MILLIS = 5000;
 
-    private Player player;
+    private final Player player;
     private Path file;
-    private AtomicLong bytesTransferred = new AtomicLong();
-    private AtomicLong bytesSkipped = new AtomicLong();
-    private AtomicLong bytesTotal;
+    private final AtomicLong bytesTransferred = new AtomicLong();
+    private final AtomicLong bytesSkipped = new AtomicLong();
+    private final AtomicLong bytesTotal = new AtomicLong();
     private final SampleHistory history = new SampleHistory();
-    private boolean terminated;
-    private boolean active = true;
+    private volatile boolean terminated;
+    private volatile boolean active = true;
 
     public TransferStatus(Player player) {
         this.player = player;

--- a/airsonic-main/src/main/java/org/airsonic/player/io/PlayQueueInputStream.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/io/PlayQueueInputStream.java
@@ -95,7 +95,7 @@ public class PlayQueueInputStream extends InputStream {
             close();
             return read(b, off, len);
         } else {
-            status.addBytesTransfered(n);
+            status.addBytesTransferred(n);
         }
         return n;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxJavaService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxJavaService.java
@@ -184,7 +184,7 @@ public class JukeboxJavaService {
         }
         status = statusService.createStreamStatus(player);
         status.setFile(file.getFile());
-        status.addBytesTransfered(file.getFileSize());
+        status.addBytesTransferred(file.getFileSize());
         mediaFileService.incrementPlayCount(file);
         scrobble(player, file, false);
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxLegacySubsonicService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxLegacySubsonicService.java
@@ -160,7 +160,7 @@ public class JukeboxLegacySubsonicService implements AudioPlayer.Listener {
         LOG.info(player.getUsername() + " starting jukebox for \"" + FileUtil.getShortPath(file.getFile()) + "\"");
         status = statusService.createStreamStatus(player);
         status.setFile(file.getFile());
-        status.addBytesTransfered(file.getFileSize());
+        status.addBytesTransferred(file.getFileSize());
         mediaFileService.incrementPlayCount(file);
         scrobble(file, false);
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/StatusService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/StatusService.java
@@ -30,7 +30,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -129,7 +128,7 @@ public class StatusService {
         List<PlayStatus> remotePlaySnapshot = new ArrayList<>(remotePlays);
 
         return Stream.concat(
-                remotePlaySnapshot.parallelStream().filter(Predicate.not(PlayStatus::isExpired)),
+                remotePlaySnapshot.parallelStream().filter(r -> !r.isExpired()),
                 getAllStreamStatuses().parallelStream().map(streamStatus -> {
                     Path file = streamStatus.getFile();
                     if (file == null) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/StatusService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/StatusService.java
@@ -29,6 +29,10 @@ import org.springframework.stereotype.Service;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Provides services for maintaining the list of stream, download and upload statuses.
@@ -38,136 +42,112 @@ import java.util.*;
  * @author Sindre Mehus
  * @see TransferStatus
  */
-//TODO needs to be rewritten to avoid so many sync locks
 @Service
 public class StatusService {
 
     @Autowired
     private MediaFileService mediaFileService;
 
-    private final List<TransferStatus> streamStatuses = new ArrayList<TransferStatus>();
-    private final List<TransferStatus> downloadStatuses = new ArrayList<TransferStatus>();
-    private final List<TransferStatus> uploadStatuses = new ArrayList<TransferStatus>();
-    private final List<PlayStatus> remotePlays = new ArrayList<PlayStatus>();
+    private final List<TransferStatus> streamStatuses = Collections.synchronizedList(new ArrayList<>());
+    private final List<TransferStatus> downloadStatuses = Collections.synchronizedList(new ArrayList<>());
+    private final List<TransferStatus> uploadStatuses = Collections.synchronizedList(new ArrayList<>());
+    private final List<PlayStatus> remotePlays = Collections.synchronizedList(new ArrayList<>());
 
     // Maps from player ID to latest inactive stream status.
-    private final Map<Integer, TransferStatus> inactiveStreamStatuses = new LinkedHashMap<Integer, TransferStatus>();
+    private final Map<Integer, TransferStatus> inactiveStreamStatuses = new ConcurrentHashMap<>();
 
-    public synchronized TransferStatus createStreamStatus(Player player) {
-        // Reuse existing status, if possible.
-        TransferStatus status = inactiveStreamStatuses.get(player.getId());
-        if (status != null) {
-            status.setActive(true);
-        } else {
-            status = createStatus(player, streamStatuses);
-        }
-        return status;
+    public TransferStatus createStreamStatus(Player player) {
+        return createStatus(player, streamStatuses);
     }
 
-    public synchronized void removeStreamStatus(TransferStatus status) {
+    public void removeStreamStatus(TransferStatus status) {
         // Move it to the map of inactive statuses.
-        status.setActive(false);
-        inactiveStreamStatuses.put(status.getPlayer().getId(), status);
-        streamStatuses.remove(status);
+        inactiveStreamStatuses.compute(status.getPlayer().getId(), (k, v) -> {
+            streamStatuses.remove(status);
+            status.setActive(false);
+            return status;
+        });
     }
 
-    public synchronized List<TransferStatus> getAllStreamStatuses() {
-
-        List<TransferStatus> result = new ArrayList<TransferStatus>(streamStatuses);
-
+    public List<TransferStatus> getAllStreamStatuses() {
+        List<TransferStatus> snapshot = new ArrayList<>(streamStatuses);
+        Set<Integer> playerIds = snapshot.parallelStream()
+                .map(x -> x.getPlayer().getId())
+                .collect(Collectors.toCollection(() -> ConcurrentHashMap.newKeySet()));
         // Add inactive status for those players that have no active status.
-        Set<Integer> activePlayers = new HashSet<Integer>();
-        for (TransferStatus status : streamStatuses) {
-            activePlayers.add(status.getPlayer().getId());
-        }
-
-        for (Map.Entry<Integer, TransferStatus> entry : inactiveStreamStatuses.entrySet()) {
-            if (!activePlayers.contains(entry.getKey())) {
-                result.add(entry.getValue());
-            }
-        }
-        return result;
+        return Stream.concat(
+                snapshot.parallelStream(),
+                inactiveStreamStatuses.values().parallelStream().filter(s -> !playerIds.contains(s.getPlayer().getId())))
+                .collect(Collectors.toList());
     }
 
-    public synchronized List<TransferStatus> getStreamStatusesForPlayer(Player player) {
-        List<TransferStatus> result = new ArrayList<TransferStatus>();
-        for (TransferStatus status : streamStatuses) {
-            if (status.getPlayer().getId().equals(player.getId())) {
-                result.add(status);
-            }
+    public List<TransferStatus> getStreamStatusesForPlayer(Player player) {
+        // unsynchronized stream access, but should be okay, we'll just be a bit behind
+        List<TransferStatus> result = streamStatuses.parallelStream()
+                .filter(s -> s.getPlayer().getId().equals(player.getId()))
+                .collect(Collectors.toList());
+
+        if (!result.isEmpty()) {
+            return result;
         }
 
-        // If no active statuses exists, add the inactive one.
-        if (result.isEmpty()) {
-            TransferStatus inactiveStatus = inactiveStreamStatuses.get(player.getId());
-            if (inactiveStatus != null) {
-                result.add(inactiveStatus);
-            }
-        }
-
-        return result;
+        return Optional.ofNullable(inactiveStreamStatuses.get(player.getId()))
+                .map(Collections::singletonList)
+                .orElseGet(Collections::emptyList);
     }
 
-    public synchronized TransferStatus createDownloadStatus(Player player) {
+    public TransferStatus createDownloadStatus(Player player) {
         return createStatus(player, downloadStatuses);
     }
 
-    public synchronized void removeDownloadStatus(TransferStatus status) {
+    public void removeDownloadStatus(TransferStatus status) {
         downloadStatuses.remove(status);
     }
 
-    public synchronized List<TransferStatus> getAllDownloadStatuses() {
-        return new ArrayList<TransferStatus>(downloadStatuses);
+    public List<TransferStatus> getAllDownloadStatuses() {
+        return new ArrayList<>(downloadStatuses);
     }
 
-    public synchronized TransferStatus createUploadStatus(Player player) {
+    public TransferStatus createUploadStatus(Player player) {
         return createStatus(player, uploadStatuses);
     }
 
-    public synchronized void removeUploadStatus(TransferStatus status) {
+    public void removeUploadStatus(TransferStatus status) {
         uploadStatuses.remove(status);
     }
 
-    public synchronized List<TransferStatus> getAllUploadStatuses() {
-        return new ArrayList<TransferStatus>(uploadStatuses);
+    public List<TransferStatus> getAllUploadStatuses() {
+        return new ArrayList<>(uploadStatuses);
     }
 
-    public synchronized void addRemotePlay(PlayStatus playStatus) {
+    public void addRemotePlay(PlayStatus playStatus) {
         remotePlays.removeIf(PlayStatus::isExpired);
         remotePlays.add(playStatus);
     }
 
-    public synchronized List<PlayStatus> getPlayStatuses() {
-        Map<Integer, PlayStatus> result = new LinkedHashMap<Integer, PlayStatus>();
-        for (PlayStatus remotePlay : remotePlays) {
-            if (!remotePlay.isExpired()) {
-                result.put(remotePlay.getPlayer().getId(), remotePlay);
-            }
-        }
+    public List<PlayStatus> getPlayStatuses() {
+        List<PlayStatus> remotePlaySnapshot = new ArrayList<>(remotePlays);
 
-        List<TransferStatus> statuses = new ArrayList<TransferStatus>();
-        statuses.addAll(inactiveStreamStatuses.values());
-        statuses.addAll(streamStatuses);
-
-        for (TransferStatus streamStatus : statuses) {
-            Player player = streamStatus.getPlayer();
-            Path file = streamStatus.getFile();
-            if (file == null) {
-                continue;
-            }
-            MediaFile mediaFile = mediaFileService.getMediaFile(file);
-            if (player == null || mediaFile == null) {
-                continue;
-            }
-            Instant time = Instant.now().minusMillis(streamStatus.getMillisSinceLastUpdate());
-            result.put(player.getId(), new PlayStatus(mediaFile, player, time));
-        }
-        return new ArrayList<PlayStatus>(result.values());
+        return Stream.concat(
+                remotePlaySnapshot.parallelStream().filter(Predicate.not(PlayStatus::isExpired)),
+                getAllStreamStatuses().parallelStream().map(streamStatus -> {
+                    Path file = streamStatus.getFile();
+                    if (file == null) {
+                        return null;
+                    }
+                    Player player = streamStatus.getPlayer();
+                    MediaFile mediaFile = mediaFileService.getMediaFile(file);
+                    if (player == null || mediaFile == null) {
+                        return null;
+                    }
+                    Instant time = Instant.now().minusMillis(streamStatus.getMillisSinceLastUpdate());
+                    return new PlayStatus(mediaFile, player, time);
+                }).filter(Objects::nonNull))
+                .collect(Collectors.toList());
     }
 
-    private synchronized TransferStatus createStatus(Player player, List<TransferStatus> statusList) {
-        TransferStatus status = new TransferStatus();
-        status.setPlayer(player);
+    private TransferStatus createStatus(Player player, List<TransferStatus> statusList) {
+        TransferStatus status = new TransferStatus(player);
         statusList.add(status);
         return status;
     }


### PR DESCRIPTION
Should help with performance slightly so everyone isn't locking on the object instances and waiting