### PR TITLE
DownloadController to handle headers and streams correctly

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/TransferService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/TransferService.java
@@ -45,7 +45,7 @@ public class TransferService {
         TransferStatus status = (TransferStatus) session.getAttribute(UploadController.UPLOAD_STATUS);
 
         if (status != null) {
-            return new UploadInfo(status.getBytesTransfered(), status.getBytesTotal());
+            return new UploadInfo(status.getBytesTransferred(), status.getBytesTotal());
         }
         return new UploadInfo(0L, 0L);
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -205,7 +205,7 @@ public class DownloadController {
                             settingsService.getDownloadBitrateLimiter(),
                             statusSupplier,
                             statusCloser,
-                            (input, status) -> {}),
+                        (input, status) -> {}),
                     path.getFileName().toString(),
                     file.getFileSize(),
                     changed);

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -148,7 +148,7 @@ public class DownloadController implements LastModified {
         } finally {
             if (status != null) {
                 statusService.removeDownloadStatus(status);
-                securityService.updateUserByteCounts(user, 0L, status.getBytesTransfered(), 0L);
+                securityService.updateUserByteCounts(user, 0L, status.getBytesTransferred(), 0L);
             }
         }
     }
@@ -282,12 +282,12 @@ public class DownloadController implements LastModified {
                 out.write(buf, 0, n);
 
                 // Don't sleep if outside range.
-                if (range != null && !range.contains(status.getBytesSkipped() + status.getBytesTransfered())) {
+                if (range != null && !range.contains(status.getBytesSkipped() + status.getBytesTransferred())) {
                     status.addBytesSkipped(n);
                     continue;
                 }
 
-                status.addBytesTransfered(n);
+                status.addBytesTransferred(n);
                 long after = System.currentTimeMillis();
 
                 // Calculate bitrate limit every 5 seconds.

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/JAXBWriter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/JAXBWriter.java
@@ -19,8 +19,12 @@
  */
 package org.airsonic.player.controller;
 
+import com.google.common.net.MediaType;
+
+import org.airsonic.player.controller.SubsonicRESTController.APIException;
 import org.airsonic.player.util.FileUtil;
 import org.airsonic.player.util.StringUtil;
+import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.persistence.jaxb.JAXBContext;
 import org.eclipse.persistence.jaxb.MarshallerProperties;
 import org.jdom2.Attribute;
@@ -44,6 +48,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.time.Instant;
 import java.util.GregorianCalendar;
+import java.util.Map.Entry;
 
 import static org.airsonic.player.util.XMLUtil.createSAXBuilder;
 import static org.springframework.web.bind.ServletRequestUtils.getStringParameter;
@@ -120,50 +125,72 @@ public class JAXBWriter {
     }
 
     public void writeResponse(HttpServletRequest request, HttpServletResponse httpResponse, Response jaxbResponse) {
-
-        String format = getStringParameter(request, "f", "xml");
-        String jsonpCallback = request.getParameter("callback");
-        boolean json = "json".equals(format);
-        boolean jsonp = "jsonp".equals(format) && jsonpCallback != null;
-        Marshaller marshaller;
-
-        if (json) {
-            marshaller = createJsonMarshaller();
-            httpResponse.setContentType("application/json");
-        } else if (jsonp) {
-            marshaller = createJsonMarshaller();
-            httpResponse.setContentType("text/javascript");
-        } else {
-            marshaller = createXmlMarshaller();
-            httpResponse.setContentType("text/xml");
-        }
+        Entry<String, String> serializedResp = serializeForType(request, jaxbResponse);
 
         httpResponse.setCharacterEncoding(StringUtil.ENCODING_UTF8);
+        httpResponse.setContentType(serializedResp.getKey());
 
         try {
-            StringWriter writer = new StringWriter();
-            if (jsonp) {
-                writer.append(jsonpCallback).append('(');
-            }
-            marshaller.marshal(new ObjectFactory().createSubsonicResponse(jaxbResponse), writer);
-            if (jsonp) {
-                writer.append(");");
-            }
-            httpResponse.getWriter().append(writer.getBuffer());
-        } catch (JAXBException | IOException x) {
+            httpResponse.getWriter().append(serializedResp.getValue());
+        } catch (IOException x) {
             LOG.error("Failed to marshal JAXB", x);
             throw new RuntimeException(x);
         }
     }
 
     public void writeErrorResponse(HttpServletRequest request, HttpServletResponse response,
-                                   SubsonicRESTController.ErrorCode code, String message) {
+            SubsonicRESTController.ErrorCode code, String message) {
+        Response res = createErrorResponse(code, message);
+        writeResponse(request, response, res);
+    }
+
+    public Response createErrorResponse(APIException e) {
+        return createErrorResponse(e.getError(), e.getMessage());
+    }
+
+    public Response createErrorResponse(SubsonicRESTController.ErrorCode code, String message) {
         Response res = createResponse(false);
         Error error = new Error();
         res.setError(error);
         error.setCode(code.getCode());
         error.setMessage(message);
-        writeResponse(request, response, res);
+        return res;
+    }
+
+    public Entry<String, String> serializeForType(HttpServletRequest request, Response resp) {
+        String format = getStringParameter(request, "f", "xml");
+        String jsonpCallback = request.getParameter("callback");
+        boolean json = "json".equals(format);
+        boolean jsonp = "jsonp".equals(format) && jsonpCallback != null;
+        Marshaller marshaller;
+        MediaType type;
+
+        if (json) {
+            marshaller = createJsonMarshaller();
+            type = MediaType.JSON_UTF_8;
+        } else if (jsonp) {
+            marshaller = createJsonMarshaller();
+            type = MediaType.JAVASCRIPT_UTF_8;
+        } else {
+            marshaller = createXmlMarshaller();
+            type = MediaType.XML_UTF_8;
+        }
+
+        StringWriter writer = new StringWriter();
+        try {
+            if (jsonp) {
+                writer.append(jsonpCallback).append('(');
+            }
+            marshaller.marshal(new ObjectFactory().createSubsonicResponse(resp), writer);
+            if (jsonp) {
+                writer.append(");");
+            }
+        } catch (JAXBException x) {
+            LOG.error("Failed to marshal JAXB", x);
+            throw new RuntimeException(x);
+        }
+
+        return Pair.of(type.toString(), writer.toString());
     }
 
     public XMLGregorianCalendar convertDate(Instant date) {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StatusController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StatusController.java
@@ -133,7 +133,7 @@ public class StatusController {
         }
 
         public String getBytes() {
-            return StringUtil.formatBytes(transferStatus.getBytesTransfered(), locale);
+            return StringUtil.formatBytes(transferStatus.getBytesTransferred(), locale);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -272,7 +272,7 @@ public class StreamController {
 
         } finally {
             if (status != null) {
-                securityService.updateUserByteCounts(user, status.getBytesTransfered(), 0L, 0L);
+                securityService.updateUserByteCounts(user, status.getBytesTransferred(), 0L, 0L);
                 statusService.removeStreamStatus(status);
             }
         }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/UploadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/UploadController.java
@@ -153,7 +153,7 @@ public class UploadController {
                 statusService.removeUploadStatus(status);
                 request.getSession().removeAttribute(UPLOAD_STATUS);
                 User user = securityService.getCurrentUser(request);
-                securityService.updateUserByteCounts(user, 0L, 0L, status.getBytesTransfered());
+                securityService.updateUserByteCounts(user, 0L, 0L, status.getBytesTransferred());
             }
         }
 
@@ -214,14 +214,14 @@ public class UploadController {
 
             // Throttle bitrate.
 
-            long byteCount = status.getBytesTransfered() + bytesRead;
+            long byteCount = status.getBytesTransferred() + bytesRead;
             long bitCount = byteCount * 8L;
 
             float elapsedMillis = Math.max(1, System.currentTimeMillis() - start);
             float elapsedSeconds = elapsedMillis / 1000.0F;
             long maxBitsPerSecond = getBitrateLimit();
 
-            status.setBytesTransfered(byteCount);
+            status.setBytesTransferred(byteCount);
 
             if (maxBitsPerSecond > 0) {
                 float sleepMillis = 1000.0F * (bitCount / maxBitsPerSecond - elapsedSeconds);

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/TransferStatus.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/TransferStatus.java
@@ -177,15 +177,6 @@ public class TransferStatus {
     }
 
     /**
-     * Sets the remote player for the stream.
-     *
-     * @param player The remote player for the stream.
-     */
-    public void setPlayer(Player player) {
-        this.player = player;
-    }
-
-    /**
      * Returns a history of samples for the stream
      *
      * @return A (copy of) the history list of samples.

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/TransferStatus.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/TransferStatus.java
@@ -34,14 +34,14 @@ public class TransferStatus {
     private static final int HISTORY_LENGTH = 200;
     private static final long SAMPLE_INTERVAL_MILLIS = 5000;
 
-    private Player player;
+    private final Player player;
     private Path file;
-    private AtomicLong bytesTransferred = new AtomicLong();
-    private AtomicLong bytesSkipped = new AtomicLong();
-    private AtomicLong bytesTotal;
+    private final AtomicLong bytesTransferred = new AtomicLong();
+    private final AtomicLong bytesSkipped = new AtomicLong();
+    private final AtomicLong bytesTotal = new AtomicLong();
     private final SampleHistory history = new SampleHistory();
-    private boolean terminated;
-    private boolean active = true;
+    private volatile boolean terminated;
+    private volatile boolean active = true;
 
     public TransferStatus(Player player) {
         this.player = player;

--- a/airsonic-main/src/main/java/org/airsonic/player/io/PlayQueueInputStream.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/io/PlayQueueInputStream.java
@@ -95,7 +95,7 @@ public class PlayQueueInputStream extends InputStream {
             close();
             return read(b, off, len);
         } else {
-            status.addBytesTransfered(n);
+            status.addBytesTransferred(n);
         }
         return n;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxJavaService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxJavaService.java
@@ -184,7 +184,7 @@ public class JukeboxJavaService {
         }
         status = statusService.createStreamStatus(player);
         status.setFile(file.getFile());
-        status.addBytesTransfered(file.getFileSize());
+        status.addBytesTransferred(file.getFileSize());
         mediaFileService.incrementPlayCount(file);
         scrobble(player, file, false);
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxLegacySubsonicService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxLegacySubsonicService.java
@@ -160,7 +160,7 @@ public class JukeboxLegacySubsonicService implements AudioPlayer.Listener {
         LOG.info(player.getUsername() + " starting jukebox for \"" + FileUtil.getShortPath(file.getFile()) + "\"");
         status = statusService.createStreamStatus(player);
         status.setFile(file.getFile());
-        status.addBytesTransfered(file.getFileSize());
+        status.addBytesTransferred(file.getFileSize());
         mediaFileService.incrementPlayCount(file);
         scrobble(file, false);
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/StatusService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/StatusService.java
@@ -30,7 +30,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -129,7 +128,7 @@ public class StatusService {
         List<PlayStatus> remotePlaySnapshot = new ArrayList<>(remotePlays);
 
         return Stream.concat(
-                remotePlaySnapshot.parallelStream().filter(Predicate.not(PlayStatus::isExpired)),
+                remotePlaySnapshot.parallelStream().filter(r -> !r.isExpired()),
                 getAllStreamStatuses().parallelStream().map(streamStatus -> {
                     Path file = streamStatus.getFile();
                     if (file == null) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/StatusService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/StatusService.java
@@ -29,6 +29,10 @@ import org.springframework.stereotype.Service;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Provides services for maintaining the list of stream, download and upload statuses.
@@ -38,136 +42,112 @@ import java.util.*;
  * @author Sindre Mehus
  * @see TransferStatus
  */
-//TODO needs to be rewritten to avoid so many sync locks
 @Service
 public class StatusService {
 
     @Autowired
     private MediaFileService mediaFileService;
 
-    private final List<TransferStatus> streamStatuses = new ArrayList<TransferStatus>();
-    private final List<TransferStatus> downloadStatuses = new ArrayList<TransferStatus>();
-    private final List<TransferStatus> uploadStatuses = new ArrayList<TransferStatus>();
-    private final List<PlayStatus> remotePlays = new ArrayList<PlayStatus>();
+    private final List<TransferStatus> streamStatuses = Collections.synchronizedList(new ArrayList<>());
+    private final List<TransferStatus> downloadStatuses = Collections.synchronizedList(new ArrayList<>());
+    private final List<TransferStatus> uploadStatuses = Collections.synchronizedList(new ArrayList<>());
+    private final List<PlayStatus> remotePlays = Collections.synchronizedList(new ArrayList<>());
 
     // Maps from player ID to latest inactive stream status.
-    private final Map<Integer, TransferStatus> inactiveStreamStatuses = new LinkedHashMap<Integer, TransferStatus>();
+    private final Map<Integer, TransferStatus> inactiveStreamStatuses = new ConcurrentHashMap<>();
 
-    public synchronized TransferStatus createStreamStatus(Player player) {
-        // Reuse existing status, if possible.
-        TransferStatus status = inactiveStreamStatuses.get(player.getId());
-        if (status != null) {
-            status.setActive(true);
-        } else {
-            status = createStatus(player, streamStatuses);
-        }
-        return status;
+    public TransferStatus createStreamStatus(Player player) {
+        return createStatus(player, streamStatuses);
     }
 
-    public synchronized void removeStreamStatus(TransferStatus status) {
+    public void removeStreamStatus(TransferStatus status) {
         // Move it to the map of inactive statuses.
-        status.setActive(false);
-        inactiveStreamStatuses.put(status.getPlayer().getId(), status);
-        streamStatuses.remove(status);
+        inactiveStreamStatuses.compute(status.getPlayer().getId(), (k, v) -> {
+            streamStatuses.remove(status);
+            status.setActive(false);
+            return status;
+        });
     }
 
-    public synchronized List<TransferStatus> getAllStreamStatuses() {
-
-        List<TransferStatus> result = new ArrayList<TransferStatus>(streamStatuses);
-
+    public List<TransferStatus> getAllStreamStatuses() {
+        List<TransferStatus> snapshot = new ArrayList<>(streamStatuses);
+        Set<Integer> playerIds = snapshot.parallelStream()
+                .map(x -> x.getPlayer().getId())
+                .collect(Collectors.toCollection(() -> ConcurrentHashMap.newKeySet()));
         // Add inactive status for those players that have no active status.
-        Set<Integer> activePlayers = new HashSet<Integer>();
-        for (TransferStatus status : streamStatuses) {
-            activePlayers.add(status.getPlayer().getId());
-        }
-
-        for (Map.Entry<Integer, TransferStatus> entry : inactiveStreamStatuses.entrySet()) {
-            if (!activePlayers.contains(entry.getKey())) {
-                result.add(entry.getValue());
-            }
-        }
-        return result;
+        return Stream.concat(
+                snapshot.parallelStream(),
+                inactiveStreamStatuses.values().parallelStream().filter(s -> !playerIds.contains(s.getPlayer().getId())))
+                .collect(Collectors.toList());
     }
 
-    public synchronized List<TransferStatus> getStreamStatusesForPlayer(Player player) {
-        List<TransferStatus> result = new ArrayList<TransferStatus>();
-        for (TransferStatus status : streamStatuses) {
-            if (status.getPlayer().getId().equals(player.getId())) {
-                result.add(status);
-            }
+    public List<TransferStatus> getStreamStatusesForPlayer(Player player) {
+        // unsynchronized stream access, but should be okay, we'll just be a bit behind
+        List<TransferStatus> result = streamStatuses.parallelStream()
+                .filter(s -> s.getPlayer().getId().equals(player.getId()))
+                .collect(Collectors.toList());
+
+        if (!result.isEmpty()) {
+            return result;
         }
 
-        // If no active statuses exists, add the inactive one.
-        if (result.isEmpty()) {
-            TransferStatus inactiveStatus = inactiveStreamStatuses.get(player.getId());
-            if (inactiveStatus != null) {
-                result.add(inactiveStatus);
-            }
-        }
-
-        return result;
+        return Optional.ofNullable(inactiveStreamStatuses.get(player.getId()))
+                .map(Collections::singletonList)
+                .orElseGet(Collections::emptyList);
     }
 
-    public synchronized TransferStatus createDownloadStatus(Player player) {
+    public TransferStatus createDownloadStatus(Player player) {
         return createStatus(player, downloadStatuses);
     }
 
-    public synchronized void removeDownloadStatus(TransferStatus status) {
+    public void removeDownloadStatus(TransferStatus status) {
         downloadStatuses.remove(status);
     }
 
-    public synchronized List<TransferStatus> getAllDownloadStatuses() {
-        return new ArrayList<TransferStatus>(downloadStatuses);
+    public List<TransferStatus> getAllDownloadStatuses() {
+        return new ArrayList<>(downloadStatuses);
     }
 
-    public synchronized TransferStatus createUploadStatus(Player player) {
+    public TransferStatus createUploadStatus(Player player) {
         return createStatus(player, uploadStatuses);
     }
 
-    public synchronized void removeUploadStatus(TransferStatus status) {
+    public void removeUploadStatus(TransferStatus status) {
         uploadStatuses.remove(status);
     }
 
-    public synchronized List<TransferStatus> getAllUploadStatuses() {
-        return new ArrayList<TransferStatus>(uploadStatuses);
+    public List<TransferStatus> getAllUploadStatuses() {
+        return new ArrayList<>(uploadStatuses);
     }
 
-    public synchronized void addRemotePlay(PlayStatus playStatus) {
+    public void addRemotePlay(PlayStatus playStatus) {
         remotePlays.removeIf(PlayStatus::isExpired);
         remotePlays.add(playStatus);
     }
 
-    public synchronized List<PlayStatus> getPlayStatuses() {
-        Map<Integer, PlayStatus> result = new LinkedHashMap<Integer, PlayStatus>();
-        for (PlayStatus remotePlay : remotePlays) {
-            if (!remotePlay.isExpired()) {
-                result.put(remotePlay.getPlayer().getId(), remotePlay);
-            }
-        }
+    public List<PlayStatus> getPlayStatuses() {
+        List<PlayStatus> remotePlaySnapshot = new ArrayList<>(remotePlays);
 
-        List<TransferStatus> statuses = new ArrayList<TransferStatus>();
-        statuses.addAll(inactiveStreamStatuses.values());
-        statuses.addAll(streamStatuses);
-
-        for (TransferStatus streamStatus : statuses) {
-            Player player = streamStatus.getPlayer();
-            Path file = streamStatus.getFile();
-            if (file == null) {
-                continue;
-            }
-            MediaFile mediaFile = mediaFileService.getMediaFile(file);
-            if (player == null || mediaFile == null) {
-                continue;
-            }
-            Instant time = Instant.now().minusMillis(streamStatus.getMillisSinceLastUpdate());
-            result.put(player.getId(), new PlayStatus(mediaFile, player, time));
-        }
-        return new ArrayList<PlayStatus>(result.values());
+        return Stream.concat(
+                remotePlaySnapshot.parallelStream().filter(Predicate.not(PlayStatus::isExpired)),
+                getAllStreamStatuses().parallelStream().map(streamStatus -> {
+                    Path file = streamStatus.getFile();
+                    if (file == null) {
+                        return null;
+                    }
+                    Player player = streamStatus.getPlayer();
+                    MediaFile mediaFile = mediaFileService.getMediaFile(file);
+                    if (player == null || mediaFile == null) {
+                        return null;
+                    }
+                    Instant time = Instant.now().minusMillis(streamStatus.getMillisSinceLastUpdate());
+                    return new PlayStatus(mediaFile, player, time);
+                }).filter(Objects::nonNull))
+                .collect(Collectors.toList());
     }
 
-    private synchronized TransferStatus createStatus(Player player, List<TransferStatus> statusList) {
-        TransferStatus status = new TransferStatus();
-        status.setPlayer(player);
+    private TransferStatus createStatus(Player player, List<TransferStatus> statusList) {
+        TransferStatus status = new TransferStatus(player);
         statusList.add(status);
         return status;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/spring/ResourceRegionReusableHttpMessageConverter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/spring/ResourceRegionReusableHttpMessageConverter.java
@@ -16,17 +16,6 @@
 
 package org.airsonic.player.spring;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
-import java.util.AbstractMap.SimpleEntry;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-
 import org.airsonic.player.util.FileUtil;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourceRegion;
@@ -41,6 +30,17 @@ import org.springframework.util.Assert;
 import org.springframework.util.MimeTypeUtils;
 import org.springframework.util.StreamUtils;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
 /**
  * Implementation of {@link HttpMessageConverter} that can write a single
  * {@link ResourceRegion}, or Collections of {@link ResourceRegion
@@ -48,7 +48,7 @@ import org.springframework.util.StreamUtils;
  * 5.2.3 is released with
  * https://github.com/spring-projects/spring-framework/commit/0eacb443b01833eb1b34006d74c2ee6da04af403
  * which fixes the ResourceRange InputStream non-reuse.
- * 
+ *
  * @author Brian Clozel
  * @author Juergen Hoeller
  * @author Randomnic

--- a/airsonic-main/src/main/java/org/airsonic/player/spring/ResourceRegionReusableHttpMessageConverter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/spring/ResourceRegionReusableHttpMessageConverter.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.airsonic.player.spring;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.airsonic.player.util.FileUtil;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourceRegion;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.http.converter.ResourceRegionHttpMessageConverter;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.util.StreamUtils;
+
+/**
+ * Implementation of {@link HttpMessageConverter} that can write a single
+ * {@link ResourceRegion}, or Collections of {@link ResourceRegion
+ * ResourceRegions}. This class temporarily donated to Airsonic until Spring MVC
+ * 5.2.3 is released with
+ * https://github.com/spring-projects/spring-framework/commit/0eacb443b01833eb1b34006d74c2ee6da04af403
+ * which fixes the ResourceRange InputStream non-reuse.
+ * 
+ * @author Brian Clozel
+ * @author Juergen Hoeller
+ * @author Randomnic
+ * @since 4.3
+ */
+@Component
+public class ResourceRegionReusableHttpMessageConverter extends ResourceRegionHttpMessageConverter {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void writeInternal(Object object, @Nullable Type type, HttpOutputMessage outputMessage)
+            throws IOException, HttpMessageNotWritableException {
+
+        if (object instanceof ResourceRegion) {
+            writeResourceRegion((ResourceRegion) object, outputMessage);
+        } else {
+            Collection<ResourceRegion> regions = (Collection<ResourceRegion>) object;
+            if (regions.size() == 1) {
+                writeResourceRegion(regions.iterator().next(), outputMessage);
+            } else {
+                writeResourceRegionCollection((Collection<ResourceRegion>) object, outputMessage);
+            }
+        }
+    }
+
+    private void writeResourceRegionCollection(Collection<ResourceRegion> resourceRegions,
+            HttpOutputMessage outputMessage) throws IOException {
+
+        Assert.notNull(resourceRegions, "Collection of ResourceRegion should not be null");
+        HttpHeaders responseHeaders = outputMessage.getHeaders();
+
+        MediaType contentType = responseHeaders.getContentType();
+        String boundaryString = MimeTypeUtils.generateMultipartBoundaryString();
+        responseHeaders.set(HttpHeaders.CONTENT_TYPE, "multipart/byteranges; boundary=" + boundaryString);
+        OutputStream out = outputMessage.getBody();
+        Map<Resource, Entry<InputStream, Long>> currStreams = new HashMap<>();
+
+        try {
+            for (ResourceRegion region : resourceRegions) {
+                // retrieve an existing stream or generate a new one
+                Entry<InputStream, Long> input = currStreams.computeIfAbsent(region.getResource(), FileUtil.uncheckFunction(r -> new SimpleEntry<>(r.getInputStream(), 0L)));
+
+                // offset the existing stream location from the byte start so appropriate number of bytes are skipped
+                long start = region.getPosition() - input.getValue();
+
+                // check if range is out of order (stream pointer has advanced beyond what the range is requesting)
+                if (start < 0) {
+                    // close existing
+                    input.getKey().close();
+                    // open new stream
+                    input = currStreams.computeIfPresent(region.getResource(), FileUtil.uncheckBiFunction((r, i) -> new SimpleEntry<>(r.getInputStream(), 0L)));
+
+                    // reset start
+                    start = region.getPosition();
+                }
+
+                long end = start + region.getCount() - 1;
+
+                // Writing MIME header.
+                println(out);
+                print(out, "--" + boundaryString);
+                println(out);
+                if (contentType != null) {
+                    print(out, "Content-Type: " + contentType.toString());
+                    println(out);
+                }
+                Long resourceLength = region.getResource().contentLength();
+                end = Math.min(end, resourceLength - 1);
+                print(out, "Content-Range: bytes " + region.getPosition() + '-' + (Math.min(region.getPosition() + region.getCount(), region.getResource().contentLength()) - 1) + '/' + resourceLength);
+                println(out);
+                println(out);
+                // Printing content
+                copyRange(input.getKey(), out, start, end);
+
+                //set stream position to reuse for next time
+                input.setValue(end + 1);
+            }
+        } finally {
+            currStreams.values().stream().map(e -> e.getKey()).forEach(in -> {
+                try {
+                    in.close();
+                } catch (IOException ex) {
+                    // ignore
+                }
+            });
+        }
+
+        println(out);
+        print(out, "--" + boundaryString + "--");
+    }
+
+    public static long copyRange(InputStream in, OutputStream out, long start, long end) throws IOException {
+        Assert.notNull(in, "No InputStream specified");
+        Assert.notNull(out, "No OutputStream specified");
+
+        long skipped = in.skip(start);
+        if (skipped < start) {
+            throw new IOException("Skipped only " + skipped + " bytes out of " + start + " required");
+        }
+
+        long bytesToCopy = end - start + 1;
+        byte[] buffer = new byte[Math.min(StreamUtils.BUFFER_SIZE, (int) bytesToCopy)];
+        while (bytesToCopy > 0) {
+            int bytesRead = in.read(buffer);
+            if (bytesRead == -1) {
+                break;
+            } else if (bytesRead <= bytesToCopy) {
+                out.write(buffer, 0, bytesRead);
+                bytesToCopy -= bytesRead;
+            } else {
+                out.write(buffer, 0, (int) bytesToCopy);
+                bytesToCopy = 0;
+            }
+        }
+        return (end - start + 1 - bytesToCopy);
+    }
+
+    private static void println(OutputStream os) throws IOException {
+        os.write('\r');
+        os.write('\n');
+    }
+
+    private static void print(OutputStream os, String buf) throws IOException {
+        os.write(buf.getBytes(StandardCharsets.US_ASCII));
+    }
+
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/util/FileUtil.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/FileUtil.java
@@ -29,7 +29,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
@@ -82,10 +85,56 @@ public final class FileUtil {
         void accept(T t) throws E;
     }
 
+    @FunctionalInterface
+    public interface ThrowingFunction<T, S, E extends Exception> {
+        S apply(T t) throws E;
+    }
+
+    @FunctionalInterface
+    public interface ThrowingBiFunction<T, R, S, E extends Exception> {
+        S apply(T t, R r) throws E;
+    }
+
+    @FunctionalInterface
+    public interface ThrowingSupplier<T, E extends Exception> {
+        T get() throws E;
+    }
+
+    public static <T, E extends Exception> Supplier<T> uncheckSupplier(ThrowingSupplier<T, E> throwingSupplier) {
+        return () -> {
+            try {
+                return throwingSupplier.get();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
     public static <T, E extends Exception> Consumer<T> uncheck(ThrowingConsumer<T, E> throwingConsumer) {
         return i -> {
             try {
                 throwingConsumer.accept(i);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    public static <T, S, E extends Exception> Function<T, S> uncheckFunction(ThrowingFunction<T, S, E> throwingFunction) {
+        return i -> {
+            try {
+                return throwingFunction.apply(i);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    public static <T, R, S, E extends Exception> BiFunction<T, R, S> uncheckBiFunction(
+            ThrowingBiFunction<T, R, S, E> throwingBiFunction) {
+        return (i, j) -> {
+            try {
+                return throwingBiFunction.apply(i, j);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/airsonic-main/src/main/java/org/airsonic/player/util/PipeStreams.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/PipeStreams.java
@@ -41,9 +41,7 @@ public class PipeStreams {
      * @author WD
      */
 
-    public static class PipedInputStream extends InputStream
-
-    {
+    public static class PipedInputStream extends InputStream {
 
         byte[] buffer;
         boolean closed = false;
@@ -133,11 +131,6 @@ public class PipeStreams {
         }
 
         @Override
-        protected void finalize() throws Throwable {
-            close();
-        }
-
-        @Override
         public void mark(int readLimit) {
             return;
         }
@@ -181,9 +174,7 @@ public class PipeStreams {
                     try {
                         buffer.notifyAll();
                         buffer.wait();
-                    }
-
-                    catch (InterruptedException e) {
+                    } catch (InterruptedException e) {
                         throw new IOException(e.getMessage());
                     }
 
@@ -201,8 +192,8 @@ public class PipeStreams {
                 System.arraycopy(buffer, readPosition, b, off, amount);
                 readPosition += amount;
 
-                if (readPosition == buffer.length) // A lap was completed, so go back.
-                {
+                if (readPosition == buffer.length) {
+                    // A lap was completed, so go back.
                     readPosition = 0;
                     ++readLaps;
                 }
@@ -238,9 +229,7 @@ public class PipeStreams {
      * @author WD
      */
 
-    public static class PipedOutputStream extends OutputStream
-
-    {
+    public static class PipedOutputStream extends OutputStream {
 
         PipedInputStream sink;
 
@@ -294,11 +283,6 @@ public class PipeStreams {
         }
 
         @Override
-        protected void finalize() throws Throwable {
-            close();
-        }
-
-        @Override
         public void flush() throws IOException {
             synchronized (sink.buffer) {
                 // Release all readers.
@@ -338,9 +322,7 @@ public class PipeStreams {
                     try {
                         sink.buffer.notifyAll();
                         sink.buffer.wait();
-                    }
-
-                    catch (InterruptedException e) {
+                    } catch (InterruptedException e) {
                         throw new IOException(e.getMessage());
                     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/util/PipeStreams.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/PipeStreams.java
@@ -1,0 +1,506 @@
+package org.airsonic.player.util;
+
+import com.google.common.util.concurrent.RateLimiter;
+
+import org.airsonic.player.domain.TransferStatus;
+import org.springframework.core.io.Resource;
+
+import java.io.File;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URL;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ *
+ * The Piped*Stream classes are taken and modified from the proposed alternative
+ * implementation in https://bugs.openjdk.java.net/browse/JDK-4404700. The
+ * existing JDK implementation is (a) slow (uses polling with a time of 1s), and
+ * (b) "buggy" in the sense that it won't always retrieve the full requested
+ * byte range block properly (due to writer not having written in).
+ *
+ */
+public class PipeStreams {
+    /**
+     * This class is equivalent to <code>java.io.PipedInputStream</code>. In the
+     * interface it only adds a constructor which allows for specifying the buffer
+     * size. Its implementation, however, is much simpler and a lot more efficient
+     * than its equivalent. It doesn't rely on polling. Instead it uses proper
+     * synchronization with its counterpart
+     * <code>org.airsonic.player.util.PipedOutputStream</code>.
+     *
+     * Multiple readers can read from this stream concurrently. The block asked for
+     * by a reader is delivered completely, or until the end of the stream if less
+     * is available. Other readers can't come in between.
+     *
+     * @author WD
+     */
+
+    public static class PipedInputStream extends InputStream
+
+    {
+
+        byte[] buffer;
+        boolean closed = false;
+        int readLaps = 0;
+        int readPosition = 0;
+        public PipedOutputStream source;
+        int writeLaps = 0;
+        int writePosition = 0;
+
+        /**
+         * Creates an unconnected PipedInputStream with a default buffer size.
+         */
+
+        public PipedInputStream() throws IOException {
+            this(null);
+        }
+
+        /**
+         * Creates a PipedInputStream with a default buffer size and connects it to
+         * <code>source</code>.
+         *
+         * @exception IOException It was already connected.
+         */
+
+        public PipedInputStream(PipedOutputStream source) throws IOException {
+            this(source, 0x10000);
+        }
+
+        /**
+         * Creates a PipedInputStream with buffer size <code>bufferSize</code> and
+         * connects it to <code>source</code>.
+         *
+         * @exception IOException It was already connected.
+         */
+
+        public PipedInputStream(PipedOutputStream source, int bufferSize) throws IOException {
+            if (source != null) {
+                connect(source);
+            }
+
+            buffer = new byte[bufferSize];
+        }
+
+        @Override
+        public int available() throws IOException {
+            /*
+             * The circular buffer is inspected to see where the reader and the writer are
+             * located.
+             */
+
+            return writePosition > readPosition /* The writer is in the same lap. */ ? writePosition - readPosition
+                    : (writePosition < readPosition
+                            /* The writer is in the next lap. */ ? buffer.length - readPosition + 1 + writePosition
+                            :
+                            /* The writer is at the same position or a complete lap ahead. */
+                            (writeLaps > readLaps ? buffer.length : 0));
+        }
+
+        /**
+         * @exception IOException The pipe is not connected.
+         */
+
+        @Override
+        public void close() throws IOException {
+            if (source == null) {
+                throw new IOException("Unconnected pipe");
+            }
+
+            synchronized (buffer) {
+                closed = true;
+                // Release any pending writers.
+                buffer.notifyAll();
+            }
+        }
+
+        /**
+         * @exception IOException The pipe is already connected.
+         */
+
+        public void connect(PipedOutputStream source) throws IOException {
+            if (this.source != null) {
+                throw new IOException("Pipe already connected");
+            }
+
+            this.source = source;
+            source.sink = this;
+        }
+
+        @Override
+        protected void finalize() throws Throwable {
+            close();
+        }
+
+        @Override
+        public void mark(int readLimit) {
+            return;
+        }
+
+        @Override
+        public boolean markSupported() {
+            return false;
+        }
+
+        @Override
+        public int read() throws IOException {
+            byte[] b = new byte[1];
+            int result = read(b);
+
+            return result == -1 ? -1 : b[0];
+        }
+
+        @Override
+        public int read(byte[] b) throws IOException {
+            return read(b, 0, b.length);
+        }
+
+        /**
+         * @exception IOException The pipe is not connected.
+         */
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (source == null) {
+                throw new IOException("Unconnected pipe");
+            }
+
+            synchronized (buffer) {
+                if (writePosition == readPosition && writeLaps == readLaps) {
+                    if (closed) {
+                        return -1;
+                    }
+
+                    // Wait for any writer to put something in the circular buffer.
+
+                    try {
+                        buffer.notifyAll();
+                        buffer.wait();
+                    }
+
+                    catch (InterruptedException e) {
+                        throw new IOException(e.getMessage());
+                    }
+
+                    // Try again.
+
+                    return read(b, off, len);
+                }
+
+                // Don't read more than the capacity indicated by len or what's available
+                // in the circular buffer.
+
+                int amount = Math.min(len,
+                        (writePosition > readPosition ? writePosition : buffer.length) - readPosition);
+
+                System.arraycopy(buffer, readPosition, b, off, amount);
+                readPosition += amount;
+
+                if (readPosition == buffer.length) // A lap was completed, so go back.
+                {
+                    readPosition = 0;
+                    ++readLaps;
+                }
+
+                // The buffer is only released when the complete desired block was
+                // obtained.
+
+                if (amount < len) {
+                    int second = read(b, off + amount, len - amount);
+
+                    return second == -1 ? amount : amount + second;
+                } else {
+                    buffer.notifyAll();
+                }
+
+                return amount;
+            }
+        }
+
+    } // PipedInputStream
+
+    /**
+     * This class is equivalent to <code>java.io.PipedOutputStream</code>. In the
+     * interface it only adds a constructor which allows for specifying the buffer
+     * size. Its implementation, however, is much simpler and a lot more efficient
+     * than its equivalent. It doesn't rely on polling. Instead it uses proper
+     * synchronization with its counterpart
+     * <code>org.airsonic.player.util.PipeStreams.PipedInputStream</code>.
+     *
+     * Multiple writers can write in this stream concurrently. The block written by
+     * a writer is put in completely. Other writers can't come in between.
+     *
+     * @author WD
+     */
+
+    public static class PipedOutputStream extends OutputStream
+
+    {
+
+        PipedInputStream sink;
+
+        /**
+         * Creates an unconnected PipedOutputStream.
+         */
+
+        public PipedOutputStream() throws IOException {
+            this(null);
+        }
+
+        /**
+         * Creates a PipedOutputStream and connects it to <code>sink</code>.
+         *
+         * @exception IOException It was already connected.
+         */
+
+        public PipedOutputStream(PipedInputStream sink) throws IOException {
+            if (sink != null) {
+                connect(sink);
+            }
+        }
+
+        /**
+         * @exception IOException The pipe is not connected.
+         */
+
+        @Override
+        public void close() throws IOException {
+            if (sink == null) {
+                throw new IOException("Unconnected pipe");
+            }
+
+            synchronized (sink.buffer) {
+                sink.closed = true;
+                flush();
+            }
+        }
+
+        /**
+         * @exception IOException The pipe is already connected.
+         */
+
+        public void connect(PipedInputStream sink) throws IOException {
+            if (this.sink != null) {
+                throw new IOException("Pipe already connected");
+            }
+
+            this.sink = sink;
+            sink.source = this;
+        }
+
+        @Override
+        protected void finalize() throws Throwable {
+            close();
+        }
+
+        @Override
+        public void flush() throws IOException {
+            synchronized (sink.buffer) {
+                // Release all readers.
+                sink.buffer.notifyAll();
+            }
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            write(new byte[] { (byte) b });
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            write(b, 0, b.length);
+        }
+
+        /**
+         * @exception IOException The pipe is not connected or a reader has closed it.
+         */
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            if (sink == null) {
+                throw new IOException("Unconnected pipe");
+            }
+
+            if (sink.closed) {
+                throw new IOException("Broken pipe");
+            }
+
+            synchronized (sink.buffer) {
+                if (sink.writePosition == sink.readPosition && sink.writeLaps > sink.readLaps) {
+                    // The circular buffer is full, so wait for some reader to consume
+                    // something.
+
+                    try {
+                        sink.buffer.notifyAll();
+                        sink.buffer.wait();
+                    }
+
+                    catch (InterruptedException e) {
+                        throw new IOException(e.getMessage());
+                    }
+
+                    // Try again.
+
+                    write(b, off, len);
+
+                    return;
+                }
+
+                // Don't write more than the capacity indicated by len or the space
+                // available in the circular buffer.
+
+                int amount = Math.min(len,
+                        (sink.writePosition < sink.readPosition ? sink.readPosition : sink.buffer.length)
+                                - sink.writePosition);
+
+                System.arraycopy(b, off, sink.buffer, sink.writePosition, amount);
+                sink.writePosition += amount;
+
+                if (sink.writePosition == sink.buffer.length) {
+                    sink.writePosition = 0;
+                    ++sink.writeLaps;
+                }
+
+                // The buffer is only released when the complete desired block was
+                // written.
+
+                if (amount < len) {
+                    write(b, off + amount, len - amount);
+                } else {
+                    sink.buffer.notifyAll();
+                }
+            }
+        }
+
+    } // PipedOutputStream
+
+    public static class MonitoredInputStream extends FilterInputStream {
+        private final RateLimiter rateLimiter;
+        private final TransferStatus status;
+        private final Consumer<TransferStatus> statusCloser;
+
+        public MonitoredInputStream(InputStream delegate, RateLimiter rateLimiter,
+                Supplier<TransferStatus> statusSupplier, Consumer<TransferStatus> statusCloser,
+                BiConsumer<InputStream, TransferStatus> initAction) {
+            super(delegate);
+            this.rateLimiter = rateLimiter;
+            this.status = statusSupplier.get();
+            this.statusCloser = statusCloser;
+            initAction.accept(delegate, status);
+        }
+
+        private void acquire(int len) {
+            if (rateLimiter != null) {
+                rateLimiter.acquire(len);
+            }
+        }
+
+        @Override
+        public int read() throws IOException {
+            int read = super.read();
+            if (read >= 0) {
+                acquire(1);
+                status.addBytesTransferred(1);
+            }
+
+            return read;
+        }
+
+        @Override
+        public int read(byte b[], int off, int len) throws IOException {
+            int read = super.read(b, off, len);
+            if (read > 0) {
+                acquire(read);
+                status.addBytesTransferred(read);
+            }
+
+            return read;
+        }
+
+        @Override
+        public long skip(long n) throws IOException {
+            long skipped = super.skip(n);
+            status.addBytesSkipped(skipped);
+            return skipped;
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            statusCloser.accept(status);
+        }
+    }
+
+    public static class MonitoredResource implements Resource {
+        private final Resource delegate;
+        private final RateLimiter rateLimiter;
+        private final Supplier<TransferStatus> statusSupplier;
+        private final Consumer<TransferStatus> statusCloser;
+        private final BiConsumer<InputStream, TransferStatus> inputStreamInit;
+
+        public MonitoredResource(Resource delegate, RateLimiter rateLimiter, Supplier<TransferStatus> statusSupplier,
+                Consumer<TransferStatus> statusCloser, BiConsumer<InputStream, TransferStatus> inputStreamInit) {
+            this.delegate = delegate;
+            this.rateLimiter = rateLimiter;
+            this.statusSupplier = statusSupplier;
+            this.statusCloser = statusCloser;
+            this.inputStreamInit = inputStreamInit;
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return new MonitoredInputStream(delegate.getInputStream(), rateLimiter, statusSupplier, statusCloser, inputStreamInit);
+        }
+
+        @Override
+        public boolean exists() {
+            return delegate.exists();
+        }
+
+        @Override
+        public URL getURL() throws IOException {
+            return delegate.getURL();
+        }
+
+        @Override
+        public URI getURI() throws IOException {
+            return delegate.getURI();
+        }
+
+        @Override
+        public File getFile() throws IOException {
+            return delegate.getFile();
+        }
+
+        @Override
+        public long contentLength() throws IOException {
+            return delegate.contentLength();
+        }
+
+        @Override
+        public long lastModified() throws IOException {
+            return delegate.lastModified();
+        }
+
+        @Override
+        public Resource createRelative(String relativePath) throws IOException {
+            return delegate.createRelative(relativePath);
+        }
+
+        @Override
+        public String getFilename() {
+            return delegate.getFilename();
+        }
+
+        @Override
+        public String getDescription() {
+            return delegate.getDescription();
+        }
+
+    }
+}

--- a/airsonic-main/src/main/java/org/airsonic/player/util/StringUtil.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/util/StringUtil.java
@@ -82,6 +82,8 @@ public final class StringUtil {
             {"jpeg", "image/jpeg"},
             {"png", "image/png"},
             {"bmp", "image/bmp"},
+
+            {"zip", "application/zip"},
     };
 
     private static final String[] FILE_SYSTEM_UNSAFE = {"/", "\\", "..", ":", "\"", "?", "*", "|"};

--- a/airsonic-main/src/test/java/org/airsonic/player/util/PipeStreamsTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/util/PipeStreamsTest.java
@@ -1,0 +1,147 @@
+package org.airsonic.player.util;
+
+import com.google.common.io.Resources;
+import com.google.common.util.concurrent.RateLimiter;
+
+import org.airsonic.player.domain.TransferStatus;
+import org.airsonic.player.util.PipeStreams.MonitoredInputStream;
+import org.airsonic.player.util.PipeStreams.MonitoredResource;
+import org.airsonic.player.util.PipeStreams.PipedInputStream;
+import org.airsonic.player.util.PipeStreams.PipedOutputStream;
+import org.junit.Test;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class PipeStreamsTest {
+
+    // this test will sporadically fail with the built-in JDK Piped*Stream classes,
+    // thus we use our own
+    @Test
+    public void testPipeStreams() throws IOException {
+        byte[] b = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+        TransferStatus status = new TransferStatus(null);
+
+        try (PipedInputStream pin = new PipedInputStream(null, 5);
+                MonitoredInputStream min = new MonitoredInputStream(pin, null, () -> status, s -> {}, (i, s) -> {});
+                PipedOutputStream pout = new PipedOutputStream(pin);) {
+
+            // can initialize it in the MonitoredInputStream constructor too, but chose not
+            // to for simplicity
+            new Thread(() -> {
+                try (PipedOutputStream po = pout) {
+                    po.write(b, 4, 12);
+                } catch (IOException e) {
+                    fail("Should not throw IOException");
+                }
+            }).start();
+
+            byte[] b2 = new byte[2];
+
+            assertThat(min.read(b2)).isEqualTo(2);
+            assertThat(b2).containsExactly(4, 5);
+            assertThat(status.getBytesTransferred()).isEqualTo(2);
+            assertThat(status.getBytesSkipped()).isEqualTo(0);
+
+            assertThat(min.skip(4)).isEqualTo(4);
+            assertThat(b2).containsExactly(4, 5);
+            assertThat(status.getBytesTransferred()).isEqualTo(2);
+            assertThat(status.getBytesSkipped()).isEqualTo(4);
+
+            assertThat(min.read(b2)).isEqualTo(2);
+            assertThat(b2).containsExactly(10, 11);
+            assertThat(status.getBytesTransferred()).isEqualTo(4);
+            assertThat(status.getBytesSkipped()).isEqualTo(4);
+
+            assertThat(min.read()).isEqualTo(12);
+            assertThat(b2).containsExactly(10, 11);
+            assertThat(status.getBytesTransferred()).isEqualTo(5);
+            assertThat(status.getBytesSkipped()).isEqualTo(4);
+
+            byte[] b5 = new byte[5];
+
+            assertThat(min.read(b5)).isEqualTo(3);
+            assertThat(b5).containsExactly(13, 14, 15, 0, 0);
+            assertThat(status.getBytesTransferred()).isEqualTo(8);
+            assertThat(status.getBytesSkipped()).isEqualTo(4);
+
+            assertThat(min.read(b5)).isEqualTo(-1);
+            assertThat(b5).containsExactly(13, 14, 15, 0, 0);
+            assertThat(status.getBytesTransferred()).isEqualTo(8);
+            assertThat(status.getBytesSkipped()).isEqualTo(4);
+
+            assertThat(min.skip(4)).isEqualTo(0);
+            assertThat(status.getBytesTransferred()).isEqualTo(8);
+            assertThat(status.getBytesSkipped()).isEqualTo(4);
+
+            assertThat(min.read()).isEqualTo(-1);
+            assertThat(status.getBytesTransferred()).isEqualTo(8);
+            assertThat(status.getBytesSkipped()).isEqualTo(4);
+        }
+    }
+
+    @Test
+    public void testMonitoredResource() throws Exception {
+        TransferStatus status = new TransferStatus(null);
+        RateLimiter limit = RateLimiter.create(4.0);
+        Path file = Paths.get(Resources.getResource("MEDIAS/piano.mp3").toURI());
+        Set<String> eventSet = new HashSet<>();
+        Resource r = new MonitoredResource(new FileSystemResource(file), limit, () -> status, s -> {
+            if (!eventSet.add("statusClosed")) {
+                fail("statusClosed multiple times");
+            }
+        }, (i, s) -> {
+            if (!eventSet.add("inputStreamOpened")) {
+                fail("inputStream opened multiple times");
+            }
+        });
+
+        assertThat(r.contentLength()).isEqualTo(FileUtil.size(file));
+        assertThat(eventSet).isEmpty();
+
+        // these are timed tests and a degree of variability is to be expected
+        try (InputStream is = r.getInputStream()) {
+            assertThat(eventSet).containsOnly("inputStreamOpened");
+
+            long start = System.currentTimeMillis();
+            is.skip(2);
+            is.skip(2);
+            is.skip(2);
+            is.skip(2);
+            is.skip(2);
+            is.skip(2);
+            // skips shouldn't be rate-limited
+            assertThat(System.currentTimeMillis() - start).isLessThan(1000);
+            assertThat(status.getBytesTransferred()).isEqualTo(0);
+            assertThat(status.getBytesSkipped()).isEqualTo(12);
+            assertThat(eventSet).containsOnly("inputStreamOpened");
+
+            byte[] b = new byte[2];
+            start = System.currentTimeMillis();
+            is.read(b);
+            is.read(b);
+            is.read(b);
+            is.read(b);
+            is.read(b);
+            is.read(b);
+            is.read();
+            is.read();
+            // reads should be rate-limited
+            assertThat(System.currentTimeMillis() - start).isGreaterThan(2000);
+            assertThat(status.getBytesTransferred()).isEqualTo(14);
+            assertThat(status.getBytesSkipped()).isEqualTo(12);
+            assertThat(eventSet).containsOnly("inputStreamOpened");
+        }
+
+        assertThat(eventSet).containsOnly("inputStreamOpened", "statusClosed");
+    }
+}


### PR DESCRIPTION
This PR updates DownloadController to rely on Spring's Resources class instead of manual byte transferring.

The previous implementation had the following issues:
- ETags used only for MediaFiles, and prone to issues
  - The ETag in use (when used) was the MediaFile id which does not guarantee that the underlying resource has changed, making caching incorrect or useless
- Last-Modified only used for MediaFiles
- Range requests are incorrectly implemented and do not comply with IETF RFC7233 (https://tools.ietf.org/html/rfc7233)
  - Range requests only implemented for MediaFiles
  - Only some types of range requests supported (no suffix byte ranges, or multiple ranges)
  - Content-Range header incorrectly set for 206 Partial Content responses, even for MediaFiles
  - This effectively makes Range requests non-compliant and useless
- MediaTypes are incorrectly set (IANA does not recognize an "x-download" subtype: https://www.iana.org/assignments/media-types/media-types.xhtml)
- Zip file length unknown and therefore Content-Length not set, leading to unknown download time calculation by clients
- Attachment file names have to be manually encoded into RFC5987
- Rates are checked every few seconds instead of monitoring progress continuously

The new implementation delegates to Spring as much as possible.
Notes:
- Zip file sizes are now calculatable, full download length is known for all types of downloads
- ETags are now file sizes, it is a more accurate representation of file contents (and is part of the ETag used by web servers such as Apache httpd)
  - Allows ETags to be specified for everything instead of just MediaFiles resulting in a much more effective client cache strategy
- Single files are FileResources and served as is, they support byte Ranges, Last-Modified etc.
- Multiple files are zipped and served as modified version of a InputStreamResource that has known content length (allowing us to get around Spring not supporting Range requests for InputStreamResource)
  - It uses custom implementations of Pipes*Streams due to a bug in JDK versions where the internal circular buffer isn't properly copied over, plus is less performant (time-based polling leading to sleep times of at least 1s, instead of waking up threads when ready).
  - Due to zip file size known beforehand, the Content-Range header can be set appropriately
  - ETag is also known and set (zip file size)
  - Last-Modified is not set for zip downloads
- All IO is kept track of by using Monitored* streams, which monitors progress as well as rate limits as appropriate
- RateLimiter is introduced to properly allocate rate allowance instead of the kludgy way we handle rates
- This PR contains a temporary fix for a Spring bug https://github.com/spring-projects/spring-framework/commit/0eacb443b01833eb1b34006d74c2ee6da04af403 which may be removed after 5.2.3 is released