### PR TITLE
Update byte counts safely and not unnecessarily rewrite the roles

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
@@ -173,6 +173,11 @@ public class UserDao extends AbstractDao {
         writeRoles(user);
     }
 
+    public void updateUserByteCounts(String user, long bytesStreamedDelta, long bytesDownloadedDelta, long bytesUploadedDelta) {
+        String sql = "update " + getUserTable() + " set bytes_streamed=bytes_streamed+?, bytes_downloaded=bytes_downloaded+?, bytes_uploaded=bytes_uploaded+? where username=?";
+        update(sql, bytesStreamedDelta, bytesDownloadedDelta, bytesUploadedDelta, user);
+    }
+
     /**
      * Returns the name of the roles for the given user.
      *
@@ -324,6 +329,7 @@ public class UserDao extends AbstractDao {
     }
 
     private class UserRowMapper implements RowMapper<User> {
+        @Override
         public User mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new User(rs.getString(1),
                     decrypt(rs.getString(2)),
@@ -336,6 +342,7 @@ public class UserDao extends AbstractDao {
     }
 
     private static class UserSettingsRowMapper implements RowMapper<UserSettings> {
+        @Override
         public UserSettings mapRow(ResultSet rs, int rowNum) throws SQLException {
             int col = 1;
             UserSettings settings = new UserSettings(rs.getString(col++));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
@@ -69,6 +69,7 @@ public class SecurityService implements UserDetailsService {
      * @throws UsernameNotFoundException if the user could not be found or the user has no GrantedAuthority.
      * @throws DataAccessException       If user could not be found for a repository-specific reason.
      */
+    @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException, DataAccessException {
         return loadUserByUsername(username, true);
     }
@@ -218,11 +219,12 @@ public class SecurityService implements UserDetailsService {
             return;
         }
 
-        user.setBytesStreamed(user.getBytesStreamed() + bytesStreamedDelta);
-        user.setBytesDownloaded(user.getBytesDownloaded() + bytesDownloadedDelta);
-        user.setBytesUploaded(user.getBytesUploaded() + bytesUploadedDelta);
+        userDao.updateUserByteCounts(user.getUsername(), bytesStreamedDelta, bytesDownloadedDelta, bytesUploadedDelta);
 
-        userDao.updateUser(user);
+        User updated = userDao.getUserByName(user.getUsername(), true);
+        user.setBytesStreamed(updated.getBytesStreamed());
+        user.setBytesDownloaded(updated.getBytesDownloaded());
+        user.setBytesUploaded(updated.getBytesUploaded());
     }
 
     /**


### PR DESCRIPTION
Currently we completely overwrite and revamp user tables when updating byte counts.

This leads to race conditions such as:
- User changes song
- TransferStatus want to update user's byte counts for the previous song
- As part of the `updateUser()` call, user roles are deleted
- In a different thread, new song request checks auth access and sees no roles for the user, thus is denied.
- User roles are added again by thread 1.

Additionally this may lead to issues like:
- Shutdown in the middle of a byte update call will lead to user roles getting deleted