### PR TITLE
Do a sanity arg length check before sending sql to db to retrieve credentials

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
@@ -35,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -115,6 +116,9 @@ public class UserDao extends AbstractDao {
     }
 
     public List<UserCredential> getCredentials(String username, App... apps) {
+        if (apps.length == 0) {
+            return Collections.emptyList();
+        }
         String sql = "select " + USER_CREDENTIALS_COLUMNS + " from user_credentials where username=:user and app in (:apps)";
         return namedQuery(sql, userCredentialRowMapper, ImmutableMap.of("user", username, "apps", Arrays.asList(apps)));
     }


### PR DESCRIPTION
Problem appears when we retrieve creds with no Apps as args.

This may happen if neither Last.fm nor Listenbrainz are enabled in AudioScrobblerService (so we shouldn't even check the db for creds at all).

Manifests as
```
org.springframework.jdbc.BadSqlGrammarException: PreparedStatementCallback; bad SQL grammar [select username, app_username, credential, encoder, app, created, updated, expiration, comment from user_credentials where username=? and app in ()]; nested exception is java.sql.SQLException: Unexpected token: ) in statement [select username, app_username, credential, encoder, app, created, updated, expiration, comment from user_credentials where username=? and app in ()]
        at org.springframework.jdbc.support.SQLStateSQLExceptionTranslator.doTranslate(SQLStateSQLExceptionTranslator.java:101) ~[spring-jdbc-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:72) ~[spring-jdbc-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:81) ~[spring-jdbc-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:81) ~[spring-jdbc-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.translateException(JdbcTemplate.java:1443) ~[spring-jdbc-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:633) ~[spring-jdbc-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:669) ~[spring-jdbc-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:694) ~[spring-jdbc-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:748) ~[spring-jdbc-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate.query(NamedParameterJdbcTemplate.java:216) ~[spring-jdbc-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate.query(NamedParameterJdbcTemplate.java:223) ~[spring-jdbc-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.airsonic.player.dao.AbstractDao.namedQuery(AbstractDao.java:123) ~[classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.dao.UserDao.getCredentials_aroundBody2(UserDao.java:119) ~[classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.dao.UserDao$AjcClosure3.run(UserDao.java:1) ~[classes!/:10.6.0-SNAPSHOT]
        at org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96cproceed(AbstractTransactionAspect.aj:66) ~[spring-aspects-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.transaction.aspectj.AbstractTransactionAspect$AbstractTransactionAspect$1.proceedWithInvocation(AbstractTransactionAspect.aj:72) ~[spring-aspects-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:366) ~[spring-tx-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96c(AbstractTransactionAspect.aj:70) ~[spring-aspects-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.airsonic.player.dao.UserDao.getCredentials(UserDao.java:117) ~[classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.dao.UserDao$$FastClassBySpringCGLIB$$2f7a4400.invoke(<generated>) ~[classes!/:10.6.0-SNAPSHOT]
        at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:769) ~[spring-aop-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:747) ~[spring-aop-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:139) ~[spring-tx-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:747) ~[spring-aop-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:366) ~[spring-tx-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:99) ~[spring-tx-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:747) ~[spring-aop-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:689) ~[spring-aop-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.airsonic.player.dao.UserDao$$EnhancerBySpringCGLIB$$415ec7f7.getCredentials(<generated>) ~[classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.service.SecurityService.getCredentials(SecurityService.java:158) ~[classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.service.SecurityService.getDecodableCredsForApps(SecurityService.java:162) ~[classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.service.AudioScrobblerService.register(AudioScrobblerService.java:90) ~[classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.controller.StreamController.scrobble(StreamController.java:282) ~[classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.controller.StreamController.lambda$7(StreamController.java:219) ~[classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.io.PlayQueueInputStream.closeStream(PlayQueueInputStream.java:83) ~[classes!/:10.6.0-SNAPSHOT]
        at org.airsonic.player.io.PlayQueueInputStream.close(PlayQueueInputStream.java:90) ~[classes!/:10.6.0-SNAPSHOT]
        at java.base/java.io.FilterInputStream.close(FilterInputStream.java:180) ~[na:na]
        at java.base/java.io.FilterInputStream.close(FilterInputStream.java:180) ~[na:na]
        at org.airsonic.player.io.PipeStreams$MonitoredInputStream.close(PipeStreams.java:416) ~[classes!/:10.6.0-SNAPSHOT]
        at org.springframework.http.converter.ResourceRegionHttpMessageConverter.writeResourceRegion(ResourceRegionHttpMessageConverter.java:163) ~[spring-web-5.2.3.RELEASE.jar!/:5.2.3.RELEASE]
        at org.springframework.http.converter.ResourceRegionHttpMessageConverter
....
```