### PR TITLE
Add external db testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,26 @@ matrix:
   - jdk: openjdk11
   - jdk: openjdk12
   - jdk: openjdk13
-  
+  # test against external dbs with java lts
+  - jdk: openjdk11
+    env: DB=postgres:9.6-alpine
+    before_install:
+      - >
+        docker pull ${DB};
+        docker run --name postgres -e POSTGRES_PASSWORD=pass -p 5432:5432 -d ${DB};
+        until docker run --rm --link postgres:pg postgres:9.6-alpine pg_isready -U postgres -h pg; do sleep 1; done;
+    script:
+      - mvn -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=org.postgresql.Driver -DDatabaseConfigEmbedUrl=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified -DDatabaseConfigEmbedUsername=postgres -DDatabaseConfigEmbedPassword=pass -DDatabaseUsertableQuote=\" verify -B -P integration-test;
+  - jdk: openjdk11
+    env: DB=postgres:12.2-alpine
+    before_install:
+      - >
+        docker pull ${DB};
+        docker run --name postgres -e POSTGRES_PASSWORD=pass -p 5432:5432 -d ${DB};
+        until docker run --rm --link postgres:pg postgres:12.2-alpine pg_isready -U postgres -h pg; do sleep 1; done;
+    script:
+      - mvn -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=org.postgresql.Driver -DDatabaseConfigEmbedUrl=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified -DDatabaseConfigEmbedUsername=postgres -DDatabaseConfigEmbedPassword=pass -DDatabaseUsertableQuote=\" verify -B -P integration-test;
+
   # deploy jobs
   - name: "Deploy Edge Release"
     stage: deploy_edge

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
     before_install:
       - >
         docker pull ${DB};
-        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB} --character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci;
+        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB} --character-set-server=utf8mb4 --collation-server=utf8mb4_bin;
         until docker run --rm --link mysql:ms ${DB} mysql --host=ms --user=root --password=pass -e 'SELECT 1' &> /dev/null; do sleep 1; done;
     script:
       - docker ps
@@ -73,7 +73,7 @@ matrix:
     before_install:
       - >
         docker pull ${DB};
-        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB} --character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci;
+        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB} --character-set-server=utf8mb4 --collation-server=utf8mb4_bin;
         until docker run --rm --link mysql:ms ${DB} mysql --host=ms --user=root --password=pass -e 'SELECT 1' &> /dev/null; do sleep 1; done;
     script:
       - docker ps
@@ -83,7 +83,7 @@ matrix:
     before_install:
       - >
         docker pull ${DB};
-        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB} --character-set-server=utf8mb4;
+        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB} --character-set-server=utf8mb4 --collation-server=utf8mb4_bin;
         until docker run --rm --link mysql:ms ${DB} mysql --host=ms --user=root --password=pass -e 'SELECT 1' &> /dev/null; do sleep 1; done;
     script:
       - docker ps
@@ -93,7 +93,7 @@ matrix:
     before_install:
       - >
         docker pull ${DB};
-        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB} --character-set-server=utf8mb4;
+        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB} --character-set-server=utf8mb4 --collation-server=utf8mb4_bin;
         until docker run --rm --link mysql:ms ${DB} mysql --host=ms --user=root --password=pass -e 'SELECT 1' &> /dev/null; do sleep 1; done;
     script:
       - docker ps

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
     before_install:
       - >
         docker pull ${DB};
-        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB};
+        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB} --character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci;
         until docker run --rm --link mysql:ms ${DB} mysql --host=ms --user=root --password=pass -e 'SELECT 1' &> /dev/null; do sleep 1; done;
     script:
       - docker ps
@@ -73,7 +73,7 @@ matrix:
     before_install:
       - >
         docker pull ${DB};
-        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB};
+        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB} --character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci;
         until docker run --rm --link mysql:ms ${DB} mysql --host=ms --user=root --password=pass -e 'SELECT 1' &> /dev/null; do sleep 1; done;
     script:
       - docker ps

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,18 +43,20 @@ matrix:
     before_install:
       - >
         docker pull ${DB};
-        docker run --name postgres -e POSTGRES_PASSWORD=pass -p 5432:5432 -d ${DB};
-        until docker run --rm --link postgres:pg postgres:9.6-alpine pg_isready -U postgres -h pg; do sleep 1; done;
+        docker run -d --name postgres -e POSTGRES_PASSWORD=pass -p 5432:5432 ${DB} -c 'log_statement=all';
+        until docker run --rm --link postgres:pg ${DB} pg_isready -U postgres -h pg; do sleep 1; done;
     script:
+      - docker ps
       - mvn -DexcludedGroups=org.airsonic.player.util.EmbeddedTestCategory -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=org.postgresql.Driver -DDatabaseConfigEmbedUrl=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified -DDatabaseConfigEmbedUsername=postgres -DDatabaseConfigEmbedPassword=pass -DDatabaseUsertableQuote=\" verify -B -P integration-test;
   - jdk: openjdk11
     env: DB=postgres:12.2-alpine
     before_install:
       - >
         docker pull ${DB};
-        docker run --name postgres -e POSTGRES_PASSWORD=pass -p 5432:5432 -d ${DB};
-        until docker run --rm --link postgres:pg postgres:12.2-alpine pg_isready -U postgres -h pg; do sleep 1; done;
+        docker run -d --name postgres -e POSTGRES_PASSWORD=pass -p 5432:5432 ${DB} -c 'log_statement=all';
+        until docker run --rm --link postgres:pg ${DB} pg_isready -U postgres -h pg; do sleep 1; done;
     script:
+      - docker ps
       - mvn -DexcludedGroups=org.airsonic.player.util.EmbeddedTestCategory -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=org.postgresql.Driver -DDatabaseConfigEmbedUrl=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified -DDatabaseConfigEmbedUsername=postgres -DDatabaseConfigEmbedPassword=pass -DDatabaseUsertableQuote=\" verify -B -P integration-test;
 
   # deploy jobs

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
       - docker ps
       - mvn -DexcludedGroups=org.airsonic.player.util.EmbeddedTestCategory -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=com.mysql.jdbc.Driver -DDatabaseConfigEmbedUrl=jdbc:mysql://localhost:3306/airsonic -DDatabaseConfigEmbedUsername=root -DDatabaseConfigEmbedPassword=pass verify -B -P integration-test;
   - jdk: openjdk11
-    env: DB=mariadb:10.1
+    env: DB=mariadb:10.2
     before_install:
       - >
         docker pull ${DB};

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,26 @@ matrix:
     script:
       - docker ps
       - mvn -DexcludedGroups=org.airsonic.player.util.EmbeddedTestCategory -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=com.mysql.jdbc.Driver -DDatabaseConfigEmbedUrl=jdbc:mysql://localhost:3306/airsonic -DDatabaseConfigEmbedUsername=root -DDatabaseConfigEmbedPassword=pass verify -B -P integration-test;
+  - jdk: openjdk11
+    env: DB=mariadb:10.1
+    before_install:
+      - >
+        docker pull ${DB};
+        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB} --character-set-server=utf8mb4;
+        until docker run --rm --link mysql:ms ${DB} mysql --host=ms --user=root --password=pass -e 'SELECT 1' &> /dev/null; do sleep 1; done;
+    script:
+      - docker ps
+      - mvn -DexcludedGroups=org.airsonic.player.util.EmbeddedTestCategory -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=org.mariadb.jdbc.Driver -DDatabaseConfigEmbedUrl=jdbc:mariadb://localhost:3306/airsonic -DDatabaseConfigEmbedUsername=root -DDatabaseConfigEmbedPassword=pass verify -B -P integration-test;
+  - jdk: openjdk11
+    env: DB=mariadb:10.5
+    before_install:
+      - >
+        docker pull ${DB};
+        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB} --character-set-server=utf8mb4;
+        until docker run --rm --link mysql:ms ${DB} mysql --host=ms --user=root --password=pass -e 'SELECT 1' &> /dev/null; do sleep 1; done;
+    script:
+      - docker ps
+      - mvn -DexcludedGroups=org.airsonic.player.util.EmbeddedTestCategory -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=org.mariadb.jdbc.Driver -DDatabaseConfigEmbedUrl=jdbc:mariadb://localhost:3306/airsonic -DDatabaseConfigEmbedUsername=root -DDatabaseConfigEmbedPassword=pass verify -B -P integration-test;
 
   # deploy jobs
   - name: "Deploy Edge Release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,26 @@ matrix:
     script:
       - docker ps
       - mvn -DexcludedGroups=org.airsonic.player.util.EmbeddedTestCategory -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=org.postgresql.Driver -DDatabaseConfigEmbedUrl=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified -DDatabaseConfigEmbedUsername=postgres -DDatabaseConfigEmbedPassword=pass -DDatabaseUsertableQuote=\" verify -B -P integration-test;
+  - jdk: openjdk11
+    env: DB=mysql:5.7
+    before_install:
+      - >
+        docker pull ${DB};
+        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB};
+        until docker run --rm --link mysql:ms ${DB} mysql --host=ms --user=root --password=pass -e 'SELECT 1' &> /dev/null; do sleep 1; done;
+    script:
+      - docker ps
+      - mvn -DexcludedGroups=org.airsonic.player.util.EmbeddedTestCategory -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=com.mysql.jdbc.Driver -DDatabaseConfigEmbedUrl=jdbc:mysql://localhost:3306/airsonic -DDatabaseConfigEmbedUsername=root -DDatabaseConfigEmbedPassword=pass verify -B -P integration-test;
+  - jdk: openjdk11
+    env: DB=mysql:8.0
+    before_install:
+      - >
+        docker pull ${DB};
+        docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=airsonic -p 3306:3306 ${DB};
+        until docker run --rm --link mysql:ms ${DB} mysql --host=ms --user=root --password=pass -e 'SELECT 1' &> /dev/null; do sleep 1; done;
+    script:
+      - docker ps
+      - mvn -DexcludedGroups=org.airsonic.player.util.EmbeddedTestCategory -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=com.mysql.jdbc.Driver -DDatabaseConfigEmbedUrl=jdbc:mysql://localhost:3306/airsonic -DDatabaseConfigEmbedUsername=root -DDatabaseConfigEmbedPassword=pass verify -B -P integration-test;
 
   # deploy jobs
   - name: "Deploy Edge Release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
         docker run --name postgres -e POSTGRES_PASSWORD=pass -p 5432:5432 -d ${DB};
         until docker run --rm --link postgres:pg postgres:9.6-alpine pg_isready -U postgres -h pg; do sleep 1; done;
     script:
-      - mvn -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=org.postgresql.Driver -DDatabaseConfigEmbedUrl=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified -DDatabaseConfigEmbedUsername=postgres -DDatabaseConfigEmbedPassword=pass -DDatabaseUsertableQuote=\" verify -B -P integration-test;
+      - mvn -DexcludedGroups=org.airsonic.player.util.EmbeddedTestCategory -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=org.postgresql.Driver -DDatabaseConfigEmbedUrl=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified -DDatabaseConfigEmbedUsername=postgres -DDatabaseConfigEmbedPassword=pass -DDatabaseUsertableQuote=\" verify -B -P integration-test;
   - jdk: openjdk11
     env: DB=postgres:12.2-alpine
     before_install:
@@ -55,7 +55,7 @@ matrix:
         docker run --name postgres -e POSTGRES_PASSWORD=pass -p 5432:5432 -d ${DB};
         until docker run --rm --link postgres:pg postgres:12.2-alpine pg_isready -U postgres -h pg; do sleep 1; done;
     script:
-      - mvn -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=org.postgresql.Driver -DDatabaseConfigEmbedUrl=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified -DDatabaseConfigEmbedUsername=postgres -DDatabaseConfigEmbedPassword=pass -DDatabaseUsertableQuote=\" verify -B -P integration-test;
+      - mvn -DexcludedGroups=org.airsonic.player.util.EmbeddedTestCategory -DDatabaseConfigType=embed -DDatabaseConfigEmbedDriver=org.postgresql.Driver -DDatabaseConfigEmbedUrl=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified -DDatabaseConfigEmbedUsername=postgres -DDatabaseConfigEmbedPassword=pass -DDatabaseUsertableQuote=\" verify -B -P integration-test;
 
   # deploy jobs
   - name: "Deploy Edge Release"

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/AlbumDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/AlbumDao.java
@@ -25,6 +25,7 @@ import org.airsonic.player.domain.MusicFolder;
 import org.apache.commons.lang.ObjectUtils;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.file.Files;
@@ -114,7 +115,7 @@ public class AlbumDao extends AbstractDao {
      *
      * @param album The album to create/update.
      */
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void createOrUpdateAlbum(Album album) {
         String sql = "update album set " +
                      "path=?," +

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/ArtistDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/ArtistDao.java
@@ -23,6 +23,7 @@ import org.airsonic.player.domain.Artist;
 import org.airsonic.player.domain.MusicFolder;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -86,7 +87,7 @@ public class ArtistDao extends AbstractDao {
      *
      * @param artist The artist to create/update.
      */
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void createOrUpdateArtist(Artist artist) {
         String sql = "update artist set " +
                      "cover_art_path=?," +
@@ -186,6 +187,7 @@ public class ArtistDao extends AbstractDao {
     }
 
     private static class ArtistMapper implements RowMapper<Artist> {
+        @Override
         public Artist mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new Artist(
                     rs.getInt(1),

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
@@ -134,7 +135,7 @@ public class MediaFileDao extends AbstractDao {
      *
      * @param file The media file to create/update.
      */
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void createOrUpdateMediaFile(MediaFile file) {
         LOG.trace("Creating/Updating new media file at {}", file.getPath());
         String sql = "update media_file set " +

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/MusicFolderDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/MusicFolderDao.java
@@ -74,12 +74,15 @@ public class MusicFolderDao extends AbstractDao {
      * @param musicFolder The music folder to create.
      */
     public void createMusicFolder(MusicFolder musicFolder) {
-        String sql = "insert into music_folder (" + INSERT_COLUMNS + ") values (?, ?, ?, ?)";
-        update(sql, musicFolder.getPath().toString(), musicFolder.getName(), musicFolder.isEnabled(), musicFolder.getChanged());
+        if (getMusicFolderForPath(musicFolder.getPath().toString()) == null) {
+            String sql = "insert into music_folder (" + INSERT_COLUMNS + ") values (?, ?, ?, ?)";
+            update(sql, musicFolder.getPath().toString(), musicFolder.getName(), musicFolder.isEnabled(), musicFolder.getChanged());
 
-        Integer id = queryForInt("select max(id) from music_folder", 0);
-        update("insert into music_folder_user (music_folder_id, username) select ?, username from " + userDao.getUserTable(), id);
-        LOG.info("Created music folder " + musicFolder.getPath());
+            Integer id = queryForInt("select max(id) from music_folder", 0);
+
+            update("insert into music_folder_user (music_folder_id, username) select ?, username from " + userDao.getUserTable(), id);
+            LOG.info("Created music folder " + musicFolder.getPath());
+        }
     }
 
     /**
@@ -118,6 +121,7 @@ public class MusicFolderDao extends AbstractDao {
     }
 
     private static class MusicFolderRowMapper implements RowMapper<MusicFolder> {
+        @Override
         public MusicFolder mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new MusicFolder(rs.getInt(1), Paths.get(rs.getString(2)), rs.getString(3), rs.getBoolean(4), Optional.ofNullable(rs.getTimestamp(5)).map(x -> x.toInstant()).orElse(null));
         }

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/PodcastDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/PodcastDao.java
@@ -28,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -125,8 +126,10 @@ public class PodcastDao extends AbstractDao {
      */
     public List<PodcastEpisode> getEpisodes(int channelId) {
         String sql = "select " + EPISODE_QUERY_COLUMNS + " from podcast_episode where channel_id = ? " +
-                     "and status != ? order by publish_date desc";
-        return query(sql, episodeRowMapper, channelId, PodcastStatus.DELETED.name());
+                     "and status != ?";
+        List<PodcastEpisode> result = query(sql, episodeRowMapper, channelId, PodcastStatus.DELETED.name());
+        result.sort(Comparator.comparing(PodcastEpisode::getPublishDate, Comparator.nullsLast(Comparator.reverseOrder())));
+        return result;
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/PodcastDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/PodcastDao.java
@@ -110,8 +110,7 @@ public class PodcastDao extends AbstractDao {
      * @param episode The Podcast episode to create.
      */
     public void createEpisode(PodcastEpisode episode) {
-        String sql = "insert into podcast_episode (" + EPISODE_INSERT_COLUMNS + ") values (" + questionMarks(
-                EPISODE_INSERT_COLUMNS) + ")";
+        String sql = "insert into podcast_episode (" + EPISODE_INSERT_COLUMNS + ") values (" + questionMarks(EPISODE_INSERT_COLUMNS) + ")";
         update(sql, episode.getChannelId(), episode.getUrl(), episode.getPath(),
                 episode.getTitle(), episode.getDescription(), episode.getPublishDate(),
                 episode.getDuration(), episode.getBytesTotal(), episode.getBytesDownloaded(),
@@ -125,8 +124,7 @@ public class PodcastDao extends AbstractDao {
      *         reverse chronological order (newest episode first).
      */
     public List<PodcastEpisode> getEpisodes(int channelId) {
-        String sql = "select " + EPISODE_QUERY_COLUMNS + " from podcast_episode where channel_id = ? " +
-                     "and status != ?";
+        String sql = "select " + EPISODE_QUERY_COLUMNS + " from podcast_episode where channel_id = ? and status != ?";
         List<PodcastEpisode> result = query(sql, episodeRowMapper, channelId, PodcastStatus.DELETED.name());
         result.sort(Comparator.comparing(PodcastEpisode::getPublishDate, Comparator.nullsLast(Comparator.reverseOrder())));
         return result;
@@ -139,9 +137,9 @@ public class PodcastDao extends AbstractDao {
      *         reverse chronological order (newest episode first).
      */
     public List<PodcastEpisode> getNewestEpisodes(int count) {
-        String sql = "select " + EPISODE_QUERY_COLUMNS
-                     + " from podcast_episode where status = ? and publish_date is not null " +
-                     "order by publish_date desc limit ?";
+        String sql = "select " + EPISODE_QUERY_COLUMNS +
+                     " from podcast_episode where status = ? and publish_date is not null" +
+                     " order by publish_date desc limit ?";
         return query(sql, episodeRowMapper, PodcastStatus.COMPLETED.name(), count);
     }
 
@@ -187,6 +185,7 @@ public class PodcastDao extends AbstractDao {
     }
 
     private static class PodcastChannelRowMapper implements RowMapper<PodcastChannel> {
+        @Override
         public PodcastChannel mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new PodcastChannel(rs.getInt(1), rs.getString(2), rs.getString(3), rs.getString(4), rs.getString(5),
                                       PodcastStatus.valueOf(rs.getString(6)), rs.getString(7));
@@ -194,6 +193,7 @@ public class PodcastDao extends AbstractDao {
     }
 
     private static class PodcastEpisodeRowMapper implements RowMapper<PodcastEpisode> {
+        @Override
         public PodcastEpisode mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new PodcastEpisode(rs.getInt(1), rs.getInt(2), rs.getString(3), rs.getString(4), rs.getString(5),
                     rs.getString(6), Optional.ofNullable(rs.getTimestamp(7)).map(x -> x.toInstant()).orElse(null), rs.getString(8), (Long) rs.getObject(9),

--- a/airsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
@@ -64,7 +64,7 @@ public class DatabaseConfiguration {
 
     @Bean
     public SpringLiquibase liquibase(DataSource dataSource,
-                                     @Value("${DatabaseMysqlMaxlength:512}")
+                                     @Value("${DatabaseMysqlMaxlength:384}")
                                      String mysqlVarcharLimit,
                                      @Value("${DatabaseUsertableQuote:}")
                                      String userTableQuote) {

--- a/airsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
@@ -33,6 +33,7 @@ public class DatabaseConfiguration {
     @Bean
     @Profile("legacy")
     public DataSource legacyDataSource() {
+        System.out.println("Using legacy profile. Connecting to " + url + ", driver " + driver + ", user " + user);
         return DataSourceBuilder.create()
                 //hsqldb driver (1.8) doesn't support Connection.isValid for pools
                 .type(DriverManagerDataSource.class)
@@ -46,6 +47,7 @@ public class DatabaseConfiguration {
     @Bean
     @Profile("embed")
     public DataSource embedDataSource() {
+        System.out.println("Using embed profile. Connecting to " + url + ", driver " + driver + ", user " + user);
         return DataSourceBuilder.create()
                 //find connection pool automatically
                 .username(user)

--- a/airsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
@@ -33,7 +33,6 @@ public class DatabaseConfiguration {
     @Bean
     @Profile("legacy")
     public DataSource legacyDataSource() {
-        System.out.println("Using legacy profile. Connecting to " + url + ", driver " + driver + ", user " + user);
         return DataSourceBuilder.create()
                 //hsqldb driver (1.8) doesn't support Connection.isValid for pools
                 .type(DriverManagerDataSource.class)
@@ -47,7 +46,6 @@ public class DatabaseConfiguration {
     @Bean
     @Profile("embed")
     public DataSource embedDataSource() {
-        System.out.println("Using embed profile. Connecting to " + url + ", driver " + driver + ", user " + user);
         return DataSourceBuilder.create()
                 //find connection pool automatically
                 .username(user)

--- a/airsonic-main/src/main/resources/liquibase/10.6/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/10.6/changelog.xml
@@ -6,4 +6,5 @@
     <include file="support-listenbrainz.xml" relativeToChangelogFile="true"/>
     <include file="expand-durations.xml" relativeToChangelogFile="true"/>
     <include file="user-credentials.xml" relativeToChangelogFile="true"/>
+    <include file="timestamp-precision.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/10.6/timestamp-precision.xml
+++ b/airsonic-main/src/main/resources/liquibase/10.6/timestamp-precision.xml
@@ -1,0 +1,50 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="timestamp-precision" author="anon">
+        <sql dbms="mysql,mariadb" >
+        alter table user_credentials modify created datetime(6) default now(6);
+        alter table user_credentials modify updated datetime(6) default now(6);
+        alter table user_credentials modify expiration datetime(6);
+
+        alter table music_file_info modify last_played datetime(6);
+        alter table player modify last_seen datetime(6);
+
+        alter table podcast_episode modify publish_date datetime(6);
+
+        alter table system_avatar modify created_date datetime(6) default now(6);
+        alter table custom_avatar modify created_date datetime(6) default now(6);
+
+        alter table music_folder modify changed datetime(6) default now(6);
+        alter table internet_radio modify changed datetime(6) default now(6);
+        alter table user_settings modify changed datetime(6) default now(6);
+
+        alter table share modify created datetime(6);
+        alter table share modify expires datetime(6);
+        alter table share modify last_visited datetime(6);
+
+        alter table media_file modify last_played datetime(6);
+        alter table media_file modify created datetime(6);
+        alter table media_file modify changed datetime(6);
+        alter table media_file modify last_scanned datetime(6);
+        alter table media_file modify children_last_updated datetime(6);
+        alter table artist modify last_scanned datetime(6);
+        alter table album modify last_played datetime(6);
+        alter table album modify created datetime(6);
+        alter table album modify last_scanned datetime(6);
+        alter table starred_media_file modify created datetime(6);
+        alter table starred_album modify created datetime(6);
+        alter table starred_artist modify created datetime(6);
+        alter table playlist modify created datetime(6);
+        alter table playlist modify changed datetime(6);
+        alter table bookmark modify created datetime(6);
+        alter table bookmark modify changed datetime(6);
+ 
+        alter table play_queue modify changed datetime(6);
+        </sql>
+        <rollback>
+
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -3,6 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <property name="binary_type" dbms="hsqldb" value="binary" />
+    <property name="binary_type" dbms="postgresql" value="bytea" />
     <property name="binary_type" value="blob" />
     <property name="curr_date_expr" value="current_timestamp" />
     <property name="varchar_type" dbms="mariadb,mysql" value="varchar(${mysqlVarcharLimit})" />

--- a/airsonic-main/src/main/resources/liquibase/legacy/schema37.xml
+++ b/airsonic-main/src/main/resources/liquibase/legacy/schema37.xml
@@ -2,7 +2,6 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
-    <property name="curr_date_expr" value="current_timestamp" />
     <changeSet id="schema37_001" author="muff1nman">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from version where version = 13</sqlCheck>

--- a/airsonic-main/src/test/java/org/airsonic/player/TestCaseUtils.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/TestCaseUtils.java
@@ -4,7 +4,6 @@ import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 
 import org.airsonic.player.controller.JAXBWriter;
-import org.airsonic.player.dao.DaoHelper;
 import org.airsonic.player.service.MediaScannerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,9 +12,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class TestCaseUtils {
 
@@ -59,30 +55,6 @@ public class TestCaseUtils {
     }
 
     /**
-     * Constructs a map of records count per table.
-     *
-     * @param daoHelper DaoHelper object
-     * @return Map table name -> records count
-     */
-    public static Map<String, Integer> recordsInAllTables(DaoHelper daoHelper) {
-        List<String> tableNames = daoHelper.getJdbcTemplate().queryForList("" +
-                      "select table_name " +
-                      "from information_schema.system_tables " +
-                      "where table_name not like 'SYSTEM%'"
-              , String.class);
-
-        return tableNames.stream()
-                .collect(Collectors.toMap(table -> table, table -> recordsInTable(table,daoHelper)));
-    }
-
-    /**
-     * Counts records in a table.
-     */
-    public static Integer recordsInTable(String tableName, DaoHelper daoHelper) {
-        return daoHelper.getJdbcTemplate().queryForObject("select count(1) from " + tableName,Integer.class);
-    }
-
-    /**
      * Scans the music library   * @param mediaScannerService
      */
     public static void execScan(MediaScannerService mediaScannerService) {
@@ -91,7 +63,7 @@ public class TestCaseUtils {
 
         while (mediaScannerService.isScanning()) {
             try {
-                Thread.sleep(1000);
+                Thread.sleep(200);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }

--- a/airsonic-main/src/test/java/org/airsonic/player/TestCaseUtils.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/TestCaseUtils.java
@@ -43,7 +43,7 @@ public class TestCaseUtils {
      * @return current REST api version.
      */
     public static String restApiVersion() {
-        return new JAXBWriter().getRestProtocolVersion();
+        return JAXBWriter.getRestProtocolVersion();
     }
 
     /**

--- a/airsonic-main/src/test/java/org/airsonic/player/api/AirsonicRestApiIntTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/AirsonicRestApiIntTest.java
@@ -2,7 +2,6 @@ package org.airsonic.player.api;
 
 import org.airsonic.player.TestCaseUtils;
 import org.airsonic.player.util.HomeRule;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,7 +17,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -29,18 +27,13 @@ public class AirsonicRestApiIntTest {
     private static final String AIRSONIC_PASSWORD = "admin";
     private static final String EXPECTED_FORMAT = "json";
 
-    private static String AIRSONIC_API_VERSION;
+    private static String AIRSONIC_API_VERSION = TestCaseUtils.restApiVersion();
 
     @Autowired
     private MockMvc mvc;
 
     @ClassRule
     public static final HomeRule classRule = new HomeRule(); // sets airsonic.home to a temporary dir
-
-    @BeforeClass
-    public static void setupClass() {
-        AIRSONIC_API_VERSION = TestCaseUtils.restApiVersion();
-    }
 
     @Test
     public void pingTest() throws Exception {

--- a/airsonic-main/src/test/java/org/airsonic/player/api/jukebox/AbstractAirsonicRestApiJukeboxIntTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/jukebox/AbstractAirsonicRestApiJukeboxIntTest.java
@@ -74,9 +74,9 @@ public abstract class AbstractAirsonicRestApiJukeboxIntTest {
     private static DaoHelper staticDaoHelper;
 
     @Autowired
-    protected PlayerService playerService;
-    @Autowired
     private MockMvc mvc;
+    @Autowired
+    protected PlayerService playerService;
     @Autowired
     private MusicFolderDao musicFolderDao;
     @Autowired

--- a/airsonic-main/src/test/java/org/airsonic/player/api/jukebox/AbstractAirsonicRestApiJukeboxIntTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/jukebox/AbstractAirsonicRestApiJukeboxIntTest.java
@@ -122,7 +122,6 @@ public abstract class AbstractAirsonicRestApiJukeboxIntTest {
         if (!dataBasePopulated) {
             staticDaoHelper = daoHelper;
 
-            assertThat(musicFolderDao.getAllMusicFolders().size()).isEqualTo(1);
             MusicFolderTestData.getTestMusicFolders().forEach(musicFolderDao::createMusicFolder);
             settingsService.clearMusicFolderCache();
 

--- a/airsonic-main/src/test/java/org/airsonic/player/api/jukebox/AbstractAirsonicRestApiJukeboxIntTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/api/jukebox/AbstractAirsonicRestApiJukeboxIntTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractAirsonicRestApiJukeboxIntTest {
     static final String CLIENT_NAME = "airsonic";
     static final String JUKEBOX_PLAYER_NAME = CLIENT_NAME + "-jukebox";
     private static final String EXPECTED_FORMAT = "json";
-    private static String AIRSONIC_API_VERSION;
+    private static String AIRSONIC_API_VERSION = TestCaseUtils.restApiVersion();
 
     private static boolean dataBasePopulated;
     private static DaoHelper staticDaoHelper;
@@ -98,13 +98,12 @@ public abstract class AbstractAirsonicRestApiJukeboxIntTest {
 
     @BeforeClass
     public static void setupClass() {
-        AIRSONIC_API_VERSION = TestCaseUtils.restApiVersion();
         dataBasePopulated = false;
     }
 
     @AfterClass
     public static void cleanDataBase() {
-        staticDaoHelper.getJdbcTemplate().execute("DROP SCHEMA PUBLIC CASCADE");
+        staticDaoHelper.getJdbcTemplate().execute("delete from player");
         staticDaoHelper = null;
         dataBasePopulated = false;
     }

--- a/airsonic-main/src/test/java/org/airsonic/player/dao/DaoTestCaseBean2.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/dao/DaoTestCaseBean2.java
@@ -17,9 +17,9 @@ public class DaoTestCaseBean2 {
     public static final HomeRule airsonicRule = new HomeRule();
 
     @Autowired
-    GenericDaoHelper genericDaoHelper;
+    JdbcTemplate jdbcTemplate;
 
     JdbcTemplate getJdbcTemplate() {
-        return genericDaoHelper.getJdbcTemplate();
+        return jdbcTemplate;
     }
 }

--- a/airsonic-main/src/test/java/org/airsonic/player/dao/DaoTestCaseBean2.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/dao/DaoTestCaseBean2.java
@@ -7,9 +7,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@Transactional
 public class DaoTestCaseBean2 {
     @ClassRule
     public static final HomeRule airsonicRule = new HomeRule();

--- a/airsonic-main/src/test/java/org/airsonic/player/dao/MusicFolderDaoTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/dao/MusicFolderDaoTestCase.java
@@ -18,6 +18,7 @@
  Based upon Subsonic, Copyright 2009 (C) Sindre Mehus
  */
 package org.airsonic.player.dao;
+
 import org.airsonic.player.domain.MusicFolder;
 
 import org.junit.Before;
@@ -26,8 +27,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit test of {@link MusicFolderDao}.
@@ -49,8 +51,11 @@ public class MusicFolderDaoTestCase extends DaoTestCaseBean2 {
         MusicFolder musicFolder = new MusicFolder(Paths.get("path"), "name", true, Instant.now());
         musicFolderDao.createMusicFolder(musicFolder);
 
-        MusicFolder newMusicFolder = musicFolderDao.getAllMusicFolders().get(0);
-        assertMusicFolderEquals(musicFolder, newMusicFolder);
+        // no duplicates
+        musicFolderDao.createMusicFolder(new MusicFolder(Paths.get("path"), "name", true, Instant.now()));
+
+        assertThat(musicFolderDao.getAllMusicFolders()).usingElementComparatorIgnoringFields("id")
+                .containsExactly(musicFolder);
     }
 
     @Test
@@ -65,33 +70,19 @@ public class MusicFolderDaoTestCase extends DaoTestCaseBean2 {
         musicFolder.setChanged(Instant.ofEpochMilli(234234L));
         musicFolderDao.updateMusicFolder(musicFolder);
 
-        MusicFolder newMusicFolder = musicFolderDao.getAllMusicFolders().get(0);
-        assertMusicFolderEquals(musicFolder, newMusicFolder);
+        assertThat(musicFolderDao.getAllMusicFolders()).element(0).isEqualToComparingFieldByField(musicFolder);
     }
 
     @Test
     public void testDeleteMusicFolder() {
-        assertEquals("Wrong number of music folders.", 0, musicFolderDao.getAllMusicFolders().size());
+        assertThat(musicFolderDao.getAllMusicFolders()).hasSize(0);
 
         musicFolderDao.createMusicFolder(new MusicFolder(Paths.get("path"), "name", true, Instant.now()));
-        assertEquals("Wrong number of music folders.", 1, musicFolderDao.getAllMusicFolders().size());
 
-        musicFolderDao.createMusicFolder(new MusicFolder(Paths.get("path"), "name", true, Instant.now()));
-        assertEquals("Wrong number of music folders.", 2, musicFolderDao.getAllMusicFolders().size());
+        List<MusicFolder> musicFolders = musicFolderDao.getAllMusicFolders();
+        assertThat(musicFolders).hasSize(1);
 
-        musicFolderDao.deleteMusicFolder(musicFolderDao.getAllMusicFolders().get(0).getId());
-        assertEquals("Wrong number of music folders.", 1, musicFolderDao.getAllMusicFolders().size());
-
-        musicFolderDao.deleteMusicFolder(musicFolderDao.getAllMusicFolders().get(0).getId());
-        assertEquals("Wrong number of music folders.", 0, musicFolderDao.getAllMusicFolders().size());
+        musicFolderDao.deleteMusicFolder(musicFolders.get(0).getId());
+        assertThat(musicFolderDao.getAllMusicFolders()).hasSize(0);
     }
-
-    private void assertMusicFolderEquals(MusicFolder expected, MusicFolder actual) {
-        assertEquals("Wrong name.", expected.getName(), actual.getName());
-        assertEquals("Wrong path.", expected.getPath(), actual.getPath());
-        assertEquals("Wrong enabled state.", expected.isEnabled(), actual.isEnabled());
-        assertEquals("Wrong changed date.", expected.getChanged(), actual.getChanged());
-    }
-
-
 }

--- a/airsonic-main/src/test/java/org/airsonic/player/dao/UserDaoTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/dao/UserDaoTestCase.java
@@ -35,7 +35,7 @@ public class UserDaoTestCase extends DaoTestCaseBean2 {
     public void setUp() {
         getJdbcTemplate().execute("delete from user_role");
         getJdbcTemplate().execute("delete from user_credentials");
-        getJdbcTemplate().execute("delete from user");
+        getJdbcTemplate().execute("delete from " + userDao.getUserTable());
     }
 
     @Test

--- a/airsonic-main/src/test/java/org/airsonic/player/dao/UserDaoTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/dao/UserDaoTestCase.java
@@ -157,7 +157,7 @@ public class UserDaoTestCase extends DaoTestCaseBean2 {
         assertThat(userDao.getUserByName("sindre", true)).isEqualToComparingFieldByField(user);
 
         assertNull("Error in getUserByName().", userDao.getUserByName("sindre2", true));
-        assertNull("Error in getUserByName().", userDao.getUserByName("sindre ", true));
+        assertNull("Error in getUserByName().", userDao.getUserByName("Sindre ", true));
         assertNull("Error in getUserByName().", userDao.getUserByName("bente", true));
         assertNull("Error in getUserByName().", userDao.getUserByName("", true));
         assertNull("Error in getUserByName().", userDao.getUserByName(null, true));

--- a/airsonic-main/src/test/java/org/airsonic/player/service/LegacyDatabaseStartupTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/LegacyDatabaseStartupTestCase.java
@@ -1,11 +1,13 @@
 package org.airsonic.player.service;
 
 import org.airsonic.player.TestCaseUtils;
+import org.airsonic.player.util.EmbeddedTestCategory;
 import org.airsonic.player.util.FileUtils;
 import org.airsonic.player.util.HomeRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,6 +22,7 @@ import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(EmbeddedTestCategory.class)
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class LegacyDatabaseStartupTestCase {
@@ -35,6 +38,9 @@ public class LegacyDatabaseStartupTestCase {
         // have to change the url here because old db files are libresonic
         System.setProperty("DatabaseConfigEmbedUrl",
                 SettingsService.getDefaultJDBCUrl().replaceAll("airsonic$", "libresonic"));
+        System.setProperty("DatabaseConfigEmbedUsername", "sa");
+        System.setProperty("DatabaseConfigEmbedPassword", "");
+        System.setProperty("DatabaseConfigEmbedDriver", "org.hsqldb.jdbcDriver");
     }
 
     @Autowired
@@ -44,5 +50,4 @@ public class LegacyDatabaseStartupTestCase {
     public void testStartup() {
         assertThat(dataSource).isNotNull();
     }
-
 }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
@@ -137,7 +137,7 @@ public class MediaScannerServiceTestCase {
         Assert.assertEquals(5, allAlbums.size());
         System.out.println("--- *********************** ---");
 
-        List<MediaFile> listeSongs = mediaFileDao.getSongsByGenre("Baroque Instrumental", 0, 0, musicFolderDao.getAllMusicFolders());
+        List<MediaFile> listeSongs = mediaFileDao.getSongsByGenre("Baroque Instrumental", 0, Integer.MAX_VALUE, musicFolderDao.getAllMusicFolders());
         Assert.assertEquals(2, listeSongs.size());
 
         // display out metrics report

--- a/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/MediaScannerServiceTestCase.java
@@ -32,7 +32,6 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
@@ -67,9 +66,6 @@ public class MediaScannerServiceTestCase {
 
     @Autowired
     private MusicFolderDao musicFolderDao;
-
-    @Autowired
-    private DaoHelper daoHelper;
 
     @Autowired
     private MediaFileService mediaFileService;
@@ -110,12 +106,6 @@ public class MediaScannerServiceTestCase {
         Timer.Context globalTimerContext = globalTimer.time();
         TestCaseUtils.execScan(mediaScannerService);
         globalTimerContext.stop();
-
-        System.out.println("--- Report of records count per table ---");
-        Map<String, Integer> records = TestCaseUtils.recordsInAllTables(daoHelper);
-        records.keySet().forEach(tableName -> System.out.println(tableName + " : " + records.get(tableName).toString()));
-        System.out.println("--- *********************** ---");
-
 
         // Music Folder Music must have 3 children
         List<MediaFile> listeMusicChildren = mediaFileDao.getChildrenOf(MusicFolderTestData.resolveMusicFolderPath().toString());

--- a/airsonic-main/src/test/java/org/airsonic/player/service/search/AbstractAirsonicHomeTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/search/AbstractAirsonicHomeTest.java
@@ -69,7 +69,7 @@ public abstract class AbstractAirsonicHomeTest implements AirsonicHomeTest {
             dataBasePopulated().set(true);
             getMusicFolders().forEach(musicFolderDao::createMusicFolder);
             settingsService.clearMusicFolderCache();
-            // wait for previous startuo scan to finish
+            // wait for previous startup scan to finish
             while (mediaScannerService.isScanning()) {
                 try {
                     Thread.sleep(10);

--- a/airsonic-main/src/test/java/org/airsonic/player/util/EmbeddedTestCategory.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/util/EmbeddedTestCategory.java
@@ -1,0 +1,5 @@
+package org.airsonic.player.util;
+
+public interface EmbeddedTestCategory {
+
+}


### PR DESCRIPTION
Run tests against external DBs to account for regressions, incompatible SQL, migrations and variations in cross-DB behavior.

External DBs added are:
- Postgres 9.6, 12.2 (latest)
- MySQL 5.7, 8.0 (latest)
- MariaDB 10.2, 10.5 (latest)

Some tests don't make sense running against external DBs (like LegacyDB tests). These have been marked to not run for external DBs via JUnit categories.

Minor bugs that surfaced were detected and fixed.