### PR TITLE
Fix Liquibase Postgres migrations for blob broken since 3.5.2

### DIFF
--- a/airsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -3,6 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <property name="binary_type" dbms="hsqldb" value="binary" />
+    <property name="binary_type" dbms="postgresql" value="bytea" />
     <property name="binary_type" value="blob" />
     <property name="curr_date_expr" value="current_timestamp" />
     <property name="varchar_type" dbms="mariadb,mysql" value="varchar(${mysqlVarcharLimit})" />


### PR DESCRIPTION
Liquibase changed how the blob type was handled in 3.5.2 for Postgres. Prior it was a bytea, after it was an oid.

https://liquibase.jira.com/browse/CORE-1863

We changed liquibase version in https://github.com/airsonic/airsonic/commit/325938a574538d6b9bfe1d19e4c5894e5322c4a3

This manifests an exception in the migrations on a brand new db as we try and insert a file content into the db (legacy/schema035 for the system avatar)
