### PR TITLE
Fix checking whether file is in folder or not

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
@@ -460,7 +460,7 @@ public class SecurityService implements UserDetailsService {
      * @param folder The folder in question.
      * @return Whether the given file is located in the given folder.
      */
-    protected boolean isFileInFolder(String file, String folder) {
+    protected static boolean isFileInFolder(String file, String folder) {
         // Deny access if file contains ".." surrounded by slashes (or end of line).
         if (file.matches(".*(/|\\\\)\\.\\.(/|\\\\|$).*")) {
             return false;
@@ -470,7 +470,15 @@ public class SecurityService implements UserDetailsService {
         file = file.replace('\\', '/');
         folder = folder.replace('\\', '/');
 
-        return file.toUpperCase().startsWith(folder.toUpperCase());
+        return
+                // identity matches
+                // /a/ == /a, /a == /a/, /a == /a, /a/ == /a/
+                StringUtils.equalsIgnoreCase(file, folder)
+                || StringUtils.equalsIgnoreCase(file, StringUtils.appendIfMissing(folder, "/"))
+                || StringUtils.equalsIgnoreCase(StringUtils.appendIfMissing(file, "/"), folder)
+                || StringUtils.equalsIgnoreCase(StringUtils.appendIfMissing(file, "/"), StringUtils.appendIfMissing(folder, "/"))
+                // file prefix is folder (MUST append '/', otherwise /a/b2 startswith /a/b)
+                || StringUtils.startsWithIgnoreCase(file, StringUtils.appendIfMissing(folder, "/"));
     }
 
     public void setSettingsService(SettingsService settingsService) {

--- a/airsonic-main/src/test/java/org/airsonic/player/service/SecurityServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/SecurityServiceTestCase.java
@@ -19,43 +19,53 @@
  */
 package org.airsonic.player.service;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit test of {@link SecurityService}.
  *
  * @author Sindre Mehus
  */
-public class SecurityServiceTestCase extends TestCase {
+public class SecurityServiceTestCase {
 
+    @Test
     public void testIsFileInFolder() {
-        SecurityService service = new SecurityService();
+        assertTrue(SecurityService.isFileInFolder("/music/foo.mp3", "\\"));
+        assertTrue(SecurityService.isFileInFolder("/music/foo.mp3", "/"));
 
-        assertTrue(service.isFileInFolder("/music/foo.mp3", "\\"));
-        assertTrue(service.isFileInFolder("/music/foo.mp3", "/"));
+        assertTrue(SecurityService.isFileInFolder("/music/foo.mp3", "/music"));
+        assertTrue(SecurityService.isFileInFolder("\\music\\foo.mp3", "/music"));
+        assertTrue(SecurityService.isFileInFolder("/music/foo.mp3", "\\music"));
+        assertTrue(SecurityService.isFileInFolder("/music/foo.mp3", "\\music\\"));
 
-        assertTrue(service.isFileInFolder("/music/foo.mp3", "/music"));
-        assertTrue(service.isFileInFolder("\\music\\foo.mp3", "/music"));
-        assertTrue(service.isFileInFolder("/music/foo.mp3", "\\music"));
-        assertTrue(service.isFileInFolder("/music/foo.mp3", "\\music\\"));
+        assertFalse(SecurityService.isFileInFolder("", "/tmp"));
+        assertFalse(SecurityService.isFileInFolder("foo.mp3", "/tmp"));
+        assertFalse(SecurityService.isFileInFolder("/music/foo.mp3", "/tmp"));
+        assertFalse(SecurityService.isFileInFolder("/music/foo.mp3", "/tmp/music"));
 
-        assertFalse(service.isFileInFolder("", "/tmp"));
-        assertFalse(service.isFileInFolder("foo.mp3", "/tmp"));
-        assertFalse(service.isFileInFolder("/music/foo.mp3", "/tmp"));
-        assertFalse(service.isFileInFolder("/music/foo.mp3", "/tmp/music"));
+        // identity tests
+        assertTrue(SecurityService.isFileInFolder("/music/a", "/music/a"));
+        assertTrue(SecurityService.isFileInFolder("/music/a", "/music/a/"));
+        assertTrue(SecurityService.isFileInFolder("/music/a/", "/music/a/"));
+        assertTrue(SecurityService.isFileInFolder("/music/a/", "/music/a"));
+        assertFalse(SecurityService.isFileInFolder("/music/a2", "/music/a"));
+        assertFalse(SecurityService.isFileInFolder("/music/a", "/music/a2"));
 
         // Test that references to the parent directory (..) is not allowed.
-        assertTrue(service.isFileInFolder("/music/foo..mp3", "/music"));
-        assertTrue(service.isFileInFolder("/music/foo..", "/music"));
-        assertTrue(service.isFileInFolder("/music/foo.../", "/music"));
-        assertFalse(service.isFileInFolder("/music/foo/..", "/music"));
-        assertFalse(service.isFileInFolder("../music/foo", "/music"));
-        assertFalse(service.isFileInFolder("/music/../foo", "/music"));
-        assertFalse(service.isFileInFolder("/music/../bar/../foo", "/music"));
-        assertFalse(service.isFileInFolder("/music\\foo\\..", "/music"));
-        assertFalse(service.isFileInFolder("..\\music/foo", "/music"));
-        assertFalse(service.isFileInFolder("/music\\../foo", "/music"));
-        assertFalse(service.isFileInFolder("/music/..\\bar/../foo", "/music"));
+        assertTrue(SecurityService.isFileInFolder("/music/foo..mp3", "/music"));
+        assertTrue(SecurityService.isFileInFolder("/music/foo..", "/music"));
+        assertTrue(SecurityService.isFileInFolder("/music/foo.../", "/music"));
+        assertFalse(SecurityService.isFileInFolder("/music/foo/..", "/music"));
+        assertFalse(SecurityService.isFileInFolder("../music/foo", "/music"));
+        assertFalse(SecurityService.isFileInFolder("/music/../foo", "/music"));
+        assertFalse(SecurityService.isFileInFolder("/music/../bar/../foo", "/music"));
+        assertFalse(SecurityService.isFileInFolder("/music\\foo\\..", "/music"));
+        assertFalse(SecurityService.isFileInFolder("..\\music/foo", "/music"));
+        assertFalse(SecurityService.isFileInFolder("/music\\../foo", "/music"));
+        assertFalse(SecurityService.isFileInFolder("/music/..\\bar/../foo", "/music"));
     }
 }
 


### PR DESCRIPTION
There is a subtle bug, which manifests during media scans
/music/a2 is considered a part of /music/a
because the former only checks if it starts with the latter.

This manifests itself in the following scenario:
- 2 MusicFolders
  - Music
  - Music2
- During scan:
  - Music goes through the MediaFile persistence, it's root folder is located (Music starts with Music) and set to Music
  - Music2 goes through the MediaFile persistence, it's root folder is located (Music2 starts with Music) and set to Music -> INCORRECT (should be set to Music2)

This happens because identity is not being properly checked.
With this PR:
- Music2 != Music
- Music2/ != Music
- Music2 != Music/
- Music2/ != Music/
- Music2 does not start with Music/

Thus all Music checks fail, and Music2 is not considered in Music

Music2 _is_ considered in Music2:
- Music2 == Music2

The first equality check should be enough but others with trailing slashes are provided just in case.