### PR TITLE
Fix last fm issue where scrobbling does not happen

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/scrobbler/LastFMScrobbler.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/scrobbler/LastFMScrobbler.java
@@ -160,7 +160,7 @@ public class LastFMScrobbler {
         String clientVersion = "0.1";
         long timestamp = System.currentTimeMillis() / 1000L;
         String authToken = calculateAuthenticationToken(registrationData.password, timestamp);
-        URI uri = new URI("https",
+        URI uri = new URI("http",
                 /* userInfo= */ null, "post.audioscrobbler.com", -1,
                 "/",
                 String.format("hs=true&p=1.2.1&c=%s&v=%s&u=%s&t=%s&a=%s",


### PR DESCRIPTION
This is the exact change in https://github.com/airsonic/airsonic/pull/775/files

The change was somehow reverted in https://github.com/airsonic/airsonic/commit/e3b3bc9d2bf0f71f2e0d4788a704a7326de3be9b in https://github.com/airsonic/airsonic/pull/1224

Should fix https://github.com/airsonic-advanced/airsonic-advanced/issues/110