### PR TITLE
Switch to a different maven docker plugin for building

### DIFF
--- a/install/docker/pom.xml
+++ b/install/docker/pom.xml
@@ -24,23 +24,28 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.4.9</version>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>default</id>
+                        <id>build-container</id>
+                        <phase>package</phase>
                         <goals>
                             <goal>build</goal>
                         </goals>
-                        <phase>package</phase>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${docker.container.repo}</name>
+                                    <build>
+                                        <dockerFile>Dockerfile</dockerFile>
+                                        <tags>latest</tags>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <repository>${docker.container.repo}</repository>
-                    <tag>latest</tag>
-                    <retryCount>0</retryCount>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/install/docker/pom.xml
+++ b/install/docker/pom.xml
@@ -28,12 +28,13 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>build-container</id>
+                        <id>build-image</id>
                         <phase>package</phase>
                         <goals>
                             <goal>build</goal>
                         </goals>
                         <configuration>
+                            <showLogs>true</showLogs>
                             <images>
                                 <image>
                                     <name>${docker.container.repo}</name>

--- a/install/docker/pom.xml
+++ b/install/docker/pom.xml
@@ -38,7 +38,7 @@
                                 <image>
                                     <name>${docker.container.repo}</name>
                                     <build>
-                                        <dockerFile>Dockerfile</dockerFile>
+                                        <dockerFile>${project.basedir}/Dockerfile</dockerFile>
                                         <tags>latest</tags>
                                     </build>
                                 </image>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -111,7 +111,6 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.33.0</version>
                 <executions>
                     <execution>
                         <id>prepare-it-container</id>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
                     <version>0.14.0</version>
                 </plugin>
                 <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>0.33.0</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-war-plugin</artifactId>
                     <version>3.2.3</version>
                     <configuration>


### PR DESCRIPTION
Old spotify plugin isn't being maintained actively anymore, including no bugfixes etc.

Also throws the following exception at every build
```
[WARNING] unable to get access token for Google Container Registry, configuration for building image will not contain RegistryAuth for GCR
java.io.IOException: Error code 404 trying to get security access token from Compute Engine metadata for the default service account. This may be because the virtual machine instance does not have permission scopes specified.
    at com.google.auth.oauth2.ComputeEngineCredentials.refreshAccessToken (ComputeEngineCredentials.java:111)
    at com.google.auth.oauth2.OAuth2Credentials.refresh (OAuth2Credentials.java:149)
    at com.spotify.docker.client.auth.gcr.ContainerRegistryAuthSupplier$DefaultCredentialRefresher.refresh (ContainerRegistryAuthSupplier.java:195)
```