### PR TITLE
Trim user_credentials encoder

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/UserDao.java
@@ -143,7 +143,7 @@ public class UserDao extends AbstractDao {
     }
 
     public boolean createCredential(UserCredential credential) {
-        String sql = "insert into user_credentials (" + USER_CREDENTIALS_COLUMNS + ") values (" + questionMarks(USER_CREDENTIALS_COLUMNS) + ')';
+        String sql = "insert into user_credentials (" + USER_CREDENTIALS_COLUMNS + ") values (" + questionMarks(USER_CREDENTIALS_COLUMNS) + ")";
         return update(sql,
                 credential.getUsername(),
                 credential.getAppUsername(),

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/UserCredential.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/UserCredential.java
@@ -1,5 +1,7 @@
 package org.airsonic.player.domain;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.time.Instant;
 
 public class UserCredential {
@@ -19,7 +21,7 @@ public class UserCredential {
         this.username = username;
         this.appUsername = appUsername;
         this.credential = credential;
-        this.encoder = encoder;
+        this.encoder = StringUtils.trimToNull(encoder);
         this.app = app;
         this.comment = comment;
         this.expiration = expiration;
@@ -78,7 +80,7 @@ public class UserCredential {
     }
 
     public void setEncoder(String encoder) {
-        this.encoder = encoder;
+        this.encoder = StringUtils.trimToNull(encoder);
     }
 
     public App getApp() {

--- a/airsonic-main/src/main/resources/liquibase/10.6/user-credentials.xml
+++ b/airsonic-main/src/main/resources/liquibase/10.6/user-credentials.xml
@@ -4,7 +4,6 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="add-user-credentials" author="anon">
         <validCheckSum>8:9ba4c6423056729960a02fece0c68b90</validCheckSum>
-        <validCheckSum>1:any</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="user_credentials"/>
@@ -38,14 +37,14 @@
         <sql>insert into user_credentials (username, app_username, credential, encoder, app, comment)
              select u.username, u.username,
                case when u.password like 'enc:%' then substr(u.password, 5, length(u.password) - 4) else u.password end,
-               case when u.password like 'enc:%' then trim('legacyhex') else trim('legacynoop') end,
+               case when u.password like 'enc:%' then 'legacyhex' else 'legacynoop' end,
                'AIRSONIC', 'Initial legacy migration'
              from ${userTableQuote}user${userTableQuote} u
         </sql>
         <sql>insert into user_credentials (username, app_username, credential, encoder, app, comment)
              select u.username, u.last_fm_username,
                case when u.last_fm_password like 'enc:%' then substr(u.last_fm_password, 5, length(u.last_fm_password) - 4) else u.last_fm_password end,
-               case when u.last_fm_password like 'enc:%' then trim('legacyhex') else trim('legacynoop') end,
+               case when u.last_fm_password like 'enc:%' then 'legacyhex' else 'legacynoop' end,
                'LASTFM', 'Initial legacy migration'
              from user_settings u
              where u.last_fm_username is not null and u.last_fm_password is not null
@@ -53,13 +52,20 @@
         <sql>insert into user_credentials (username, app_username, credential, encoder, app, comment)
              select u.username, u.username,
                case when u.listenbrainz_token like 'enc:%' then substr(u.listenbrainz_token, 5, length(u.listenbrainz_token) - 4) else u.listenbrainz_token end,
-               case when u.listenbrainz_token like 'enc:%' then trim('legacyhex') else trim('legacynoop') end,
+               case when u.listenbrainz_token like 'enc:%' then 'legacyhex' else 'legacynoop' end,
                'LISTENBRAINZ', 'Initial legacy migration'
              from user_settings u
              where u.listenbrainz_token is not null
         </sql>
         <rollback>
             <dropTable tableName="user_credentials"/>
+        </rollback>
+    </changeSet>
+    <changeSet id="trim-user-credentials-encoder" author="anon">
+        <sql>
+            update user_credentials set encoder=trim(encoder);
+        </sql>
+        <rollback>
         </rollback>
     </changeSet>
 </databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/10.6/user-credentials.xml
+++ b/airsonic-main/src/main/resources/liquibase/10.6/user-credentials.xml
@@ -63,7 +63,7 @@
     </changeSet>
     <changeSet id="trim-user-credentials-encoder" author="anon">
         <sql>
-            update user_credentials set encoder=trim(encoder);
+            update user_credentials set encoder = trim( encoder )
         </sql>
         <rollback>
         </rollback>

--- a/airsonic-main/src/main/resources/liquibase/10.6/user-credentials.xml
+++ b/airsonic-main/src/main/resources/liquibase/10.6/user-credentials.xml
@@ -4,6 +4,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="add-user-credentials" author="anon">
         <validCheckSum>8:9ba4c6423056729960a02fece0c68b90</validCheckSum>
+        <validCheckSum>1:any</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="user_credentials"/>
@@ -37,14 +38,14 @@
         <sql>insert into user_credentials (username, app_username, credential, encoder, app, comment)
              select u.username, u.username,
                case when u.password like 'enc:%' then substr(u.password, 5, length(u.password) - 4) else u.password end,
-               case when u.password like 'enc:%' then 'legacyhex' else 'legacynoop' end,
+               case when u.password like 'enc:%' then trim('legacyhex') else trim('legacynoop') end,
                'AIRSONIC', 'Initial legacy migration'
              from ${userTableQuote}user${userTableQuote} u
         </sql>
         <sql>insert into user_credentials (username, app_username, credential, encoder, app, comment)
              select u.username, u.last_fm_username,
                case when u.last_fm_password like 'enc:%' then substr(u.last_fm_password, 5, length(u.last_fm_password) - 4) else u.last_fm_password end,
-               case when u.last_fm_password like 'enc:%' then 'legacyhex' else 'legacynoop' end,
+               case when u.last_fm_password like 'enc:%' then trim('legacyhex') else trim('legacynoop') end,
                'LASTFM', 'Initial legacy migration'
              from user_settings u
              where u.last_fm_username is not null and u.last_fm_password is not null
@@ -52,7 +53,7 @@
         <sql>insert into user_credentials (username, app_username, credential, encoder, app, comment)
              select u.username, u.username,
                case when u.listenbrainz_token like 'enc:%' then substr(u.listenbrainz_token, 5, length(u.listenbrainz_token) - 4) else u.listenbrainz_token end,
-               case when u.listenbrainz_token like 'enc:%' then 'legacyhex' else 'legacynoop' end,
+               case when u.listenbrainz_token like 'enc:%' then trim('legacyhex') else trim('legacynoop') end,
                'LISTENBRAINZ', 'Initial legacy migration'
              from user_settings u
              where u.listenbrainz_token is not null


### PR DESCRIPTION
HSQLDB 2.5 for some unknown reason puts a space after 'legacyhex' during automigrations.

A fix is to just trim the result of the migration