### PR TITLE
Optimize playqueue rendering

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -690,9 +690,6 @@
 
             if (!internetRadioEnabled) {
                 // Show star/remove buttons in all cases...
-                node.find("#starSong" + id).show();
-                node.find("#removeSong" + id).show();
-                node.find("#songIndex" + id).show();
 
                 // Show star rating
                 if (song.starred) {


### PR DESCRIPTION
Play queue display on web client is extremely slow for large play queues.

The data transfer isn't actually the bottleneck, it's actually the page rendering and the dom manipulation. For a play queue of about 800 songs, it is enough to cause the browser to bog down and lag such that it starts missing ping checks and consequently is disconnected from the server before the play queue has even rendered.

Upon profiling, the bulk of the time is actually spent in this particular section of the code, which isn't even needed considering the elements are already in a non-hidden state when cloned.

Taking out this code reduces the time spent per loop from about 1s (rendering 1 row per sec) to about 100ms. For 800 songs in a play queue, the result is rendered much much faster ~10X faster (from ~800 sec to ~80 sec).

A more complete fix is to not draw tables manually and delegate to a table drawing library, but that will be a follow up PR.
