### PR TITLE
Minor tweaks to property migration: always check if property exists + never delete if option set

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -146,7 +146,7 @@ public class SettingsService {
     private static final String KEY_DATABASE_MYSQL_VARCHAR_MAXLENGTH = "DatabaseMysqlMaxlength";
     private static final String KEY_DATABASE_USERTABLE_QUOTE = "DatabaseUsertableQuote";
 
-    public static final String KEY_PROPERTIES_FILE_UPGRADE_RETAIN_OBSOLETE_KEYS = "PropertiesFileUpgradeRetainObsoleteKeys";
+    public static final String KEY_PROPERTIES_FILE_RETAIN_OBSOLETE_KEYS = "PropertiesFileRetainObsoleteKeys";
 
     // Default values.
     private static final String DEFAULT_JWT_KEY = null;
@@ -284,7 +284,7 @@ public class SettingsService {
 
     public static void migrateKeys(Map<String, String> keyMaps) {
         ConfigurationPropertiesService cps = ConfigurationPropertiesService.getInstance();
-        Boolean retainObsoleteKeys = Optional.ofNullable(cps.getProperty(KEY_PROPERTIES_FILE_UPGRADE_RETAIN_OBSOLETE_KEYS)).map(x -> Boolean.valueOf((String) x)).orElse(true);
+        Boolean retainObsoleteKeys = Optional.ofNullable(cps.getProperty(KEY_PROPERTIES_FILE_RETAIN_OBSOLETE_KEYS)).map(x -> Boolean.valueOf((String) x)).orElse(true);
 
         // needs to be processed serially
         keyMaps.entrySet().stream().filter(e -> cps.containsKey(e.getKey())).forEach(e -> {

--- a/airsonic-main/src/test/java/org/airsonic/player/service/SettingsServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/SettingsServiceTestCase.java
@@ -187,7 +187,7 @@ public class SettingsServiceTestCase {
 
     @Test
     public void migrateKeys_deleteKeys_NonBackwardsCompatible() {
-        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_UPGRADE_RETAIN_OBSOLETE_KEYS, "false");
+        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_RETAIN_OBSOLETE_KEYS, "false");
         ConfigurationPropertiesService.getInstance().setProperty("bla", "hello");
 
         Map<String, String> keyMaps = new LinkedHashMap<>();
@@ -203,7 +203,7 @@ public class SettingsServiceTestCase {
 
     @Test
     public void migrateKeys_withKeys_ExplicitlyBackwardsCompatible() {
-        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_UPGRADE_RETAIN_OBSOLETE_KEYS, "true");
+        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_RETAIN_OBSOLETE_KEYS, "true");
         ConfigurationPropertiesService.getInstance().setProperty("bla", "hello");
         ConfigurationPropertiesService.getInstance().setProperty("bla3", "hello2");
 
@@ -242,7 +242,7 @@ public class SettingsServiceTestCase {
 
     @Test
     public void migrateKeys_withKeys_NonBackwardsCompatible() {
-        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_UPGRADE_RETAIN_OBSOLETE_KEYS, "false");
+        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_RETAIN_OBSOLETE_KEYS, "false");
         ConfigurationPropertiesService.getInstance().setProperty("bla", "hello");
         ConfigurationPropertiesService.getInstance().setProperty("bla3", "hello2");
 

--- a/airsonic-main/src/test/java/org/airsonic/player/service/SettingsServiceTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/SettingsServiceTestCase.java
@@ -182,12 +182,12 @@ public class SettingsServiceTestCase {
 
         assertEquals("hello", env.getProperty("bla"));
         assertEquals("hello", env.getProperty("bla2"));
-        assertNull(env.getProperty("bla3"));
+        assertEquals("hello", env.getProperty("bla3"));
     }
 
     @Test
     public void migrateKeys_deleteKeys_NonBackwardsCompatible() {
-        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_UPGRADE_RETAIN_COMPATIBILITY, "false");
+        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_UPGRADE_RETAIN_OBSOLETE_KEYS, "false");
         ConfigurationPropertiesService.getInstance().setProperty("bla", "hello");
 
         Map<String, String> keyMaps = new LinkedHashMap<>();
@@ -203,7 +203,7 @@ public class SettingsServiceTestCase {
 
     @Test
     public void migrateKeys_withKeys_ExplicitlyBackwardsCompatible() {
-        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_UPGRADE_RETAIN_COMPATIBILITY, "true");
+        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_UPGRADE_RETAIN_OBSOLETE_KEYS, "true");
         ConfigurationPropertiesService.getInstance().setProperty("bla", "hello");
         ConfigurationPropertiesService.getInstance().setProperty("bla3", "hello2");
 
@@ -242,7 +242,7 @@ public class SettingsServiceTestCase {
 
     @Test
     public void migrateKeys_withKeys_NonBackwardsCompatible() {
-        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_UPGRADE_RETAIN_COMPATIBILITY, "false");
+        ConfigurationPropertiesService.getInstance().setProperty(SettingsService.KEY_PROPERTIES_FILE_UPGRADE_RETAIN_OBSOLETE_KEYS, "false");
         ConfigurationPropertiesService.getInstance().setProperty("bla", "hello");
         ConfigurationPropertiesService.getInstance().setProperty("bla3", "hello2");
 


### PR DESCRIPTION
- changed name of property migration compatibility property (`PropertiesFileUpgradeRetainCompatibility` -> `PropertiesFileRetainObsoleteKeys`)
- check key exists before migrating, mostly to clear out redundant logs
- no exceptions made for deleting keys if retention property says so