### PR TITLE
Fix External Player Bug

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/PlayQueueInfo.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/PlayQueueInfo.java
@@ -20,6 +20,7 @@
 package org.airsonic.player.ajax;
 
 import org.airsonic.player.domain.PlayQueue.RepeatStatus;
+import org.airsonic.player.domain.PlayQueue.Status;
 import org.airsonic.player.util.StringUtil;
 
 import java.util.List;
@@ -32,23 +33,20 @@ import java.util.List;
 public class PlayQueueInfo {
 
     private final List<Entry> entries;
-    private final boolean stopEnabled;
+    private final Status playStatus;
     private final RepeatStatus repeatStatus;
     private final boolean shuffleRadioEnabled;
     private final boolean internetRadioEnabled;
-    private final boolean sendM3U;
     private final float gain;
     private int startPlayerAt = -1;
     private long startPlayerAtPosition; // millis
 
-    public PlayQueueInfo(List<Entry> entries, boolean stopEnabled, RepeatStatus repeatStatus,
-            boolean shuffleRadioEnabled, boolean internetRadioEnabled, boolean sendM3U, float gain) {
+    public PlayQueueInfo(List<Entry> entries, Status playStatus, RepeatStatus repeatStatus, boolean shuffleRadioEnabled, boolean internetRadioEnabled, float gain) {
         this.entries = entries;
-        this.stopEnabled = stopEnabled;
+        this.playStatus = playStatus;
         this.repeatStatus = repeatStatus;
         this.shuffleRadioEnabled = shuffleRadioEnabled;
         this.internetRadioEnabled = internetRadioEnabled;
-        this.sendM3U = sendM3U;
         this.gain = gain;
     }
 
@@ -56,16 +54,12 @@ public class PlayQueueInfo {
         return entries;
     }
 
+    public Status getPlayStatus() {
+        return playStatus;
+    }
+
     public String getDurationAsString() {
         return StringUtil.formatDuration(Math.round(1000 * entries.parallelStream().filter(e -> e.getDuration() != null).mapToDouble(Entry::getDuration).sum()), false);
-    }
-
-    public boolean isStopEnabled() {
-        return stopEnabled;
-    }
-
-    public boolean isSendM3U() {
-        return sendM3U;
     }
 
     public RepeatStatus getRepeatStatus() {

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/PlayQueueWSController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/PlayQueueWSController.java
@@ -28,7 +28,7 @@ public class PlayQueueWSController {
     @SubscribeMapping("/get")
     public PlayQueueInfo getPlayQueue(@DestinationVariable int playerId, SimpMessageHeaderAccessor headers) throws Exception {
         Player player = getPlayer(playerId, headers);
-        return playQueueService.getPlayQueueInfo(player, false);
+        return playQueueService.getPlayQueueInfo(player);
     }
 
     @MessageMapping("/start")

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/ExternalPlayerController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/ExternalPlayerController.java
@@ -131,6 +131,7 @@ public class ExternalPlayerController {
     public MediaFileWithUrlInfo addUrlInfo(HttpServletRequest request, Player player, MediaFile mediaFile, Instant expires) {
         String prefix = "ext";
         String streamUrl = jwtSecurityService.addJWTToken(
+                JWTSecurityService.USERNAME_ANONYMOUS,
                 UriComponentsBuilder
                         .fromHttpUrl(NetworkService.getBaseUrl(request) + prefix + "/stream")
                         .queryParam("id", mediaFile.getId())
@@ -141,6 +142,7 @@ public class ExternalPlayerController {
                 .toUriString();
 
         String coverArtUrl = jwtSecurityService.addJWTToken(
+                JWTSecurityService.USERNAME_ANONYMOUS,
                 UriComponentsBuilder
                         .fromHttpUrl(NetworkService.getBaseUrl(request) + prefix + "/coverArt.view")
                         .queryParam("id", mediaFile.getId())

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/HLSController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/HLSController.java
@@ -149,7 +149,7 @@ public class HLSController {
                     .queryParam("id", id)
                     .queryParam("player", player.getId())
                     .queryParam("bitRate", kbps));
-            jwtSecurityService.addJWTToken(url);
+            jwtSecurityService.addJWTToken(player.getUsername(), url);
             writer.print(url.toUriString());
             Dimension dimension = bitRate.getRight();
             if (dimension != null) {
@@ -195,7 +195,7 @@ public class HLSController {
                 builder.queryParam("x", dimension.height);
             }
         }
-        jwtSecurityService.addJWTToken(builder);
+        jwtSecurityService.addJWTToken(player.getUsername(), builder);
         return builder.toUriString();
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/M3UController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/M3UController.java
@@ -91,7 +91,7 @@ public class M3UController {
 
             String urlNoAuth = url + "player=" + player.getId() + "&id=" + mediaFile.getId() + "&suffix=." +
                     transcodingService.getSuffix(player, mediaFile, null);
-            String urlWithAuth = jwtSecurityService.addJWTToken(urlNoAuth);
+            String urlWithAuth = jwtSecurityService.addJWTToken(player.getUsername(), urlNoAuth);
             out.println(urlWithAuth);
         }
     }
@@ -111,7 +111,7 @@ public class M3UController {
         }
         out.println("#EXTM3U");
         out.println("#EXTINF:-1,Airsonic");
-        out.println(jwtSecurityService.addJWTToken(url));
+        out.println(jwtSecurityService.addJWTToken(player.getUsername(), url));
     }
 
     private String getSuffix(Player player) {

--- a/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
@@ -157,7 +157,7 @@ public class GlobalSecurityConfig extends GlobalAuthenticationConfigurerAdapter 
             AbstractAuthenticationToken token = (AbstractAuthenticationToken) event.getSource();
             Object details = token.getDetails();
             if (details instanceof WebAuthenticationDetails) {
-                LOG.info("Login failed from [" + ((WebAuthenticationDetails) details).getRemoteAddress() + "]");
+                LOG.info("Login failed from [{}]", ((WebAuthenticationDetails) details).getRemoteAddress());
             }
         }
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/security/JWTAuthenticationProvider.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/JWTAuthenticationProvider.java
@@ -41,7 +41,6 @@ public class JWTAuthenticationProvider implements AuthenticationProvider {
         String rawToken = (String) auth.getCredentials();
         DecodedJWT token = JWTSecurityService.verify(jwtKey, rawToken);
         Claim path = token.getClaim(JWTSecurityService.CLAIM_PATH);
-        authentication.setAuthenticated(true);
 
         // TODO:AD This is super unfortunate, but not sure there is a better way when using JSP
         if (StringUtils.contains(authentication.getRequestedPath(), "/WEB-INF/jsp/")) {
@@ -54,7 +53,7 @@ public class JWTAuthenticationProvider implements AuthenticationProvider {
         List<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add(new SimpleGrantedAuthority("IS_AUTHENTICATED_FULLY"));
         authorities.add(new SimpleGrantedAuthority("ROLE_TEMP"));
-        return new JWTAuthenticationToken(authorities, rawToken, authentication.getRequestedPath());
+        return new JWTAuthenticationToken(token.getSubject(), rawToken, authentication.getRequestedPath(), authorities);
     }
 
     private static boolean roughlyEqual(String expectedRaw, String requestedPathRaw) {

--- a/airsonic-main/src/main/java/org/airsonic/player/security/JWTAuthenticationToken.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/JWTAuthenticationToken.java
@@ -1,31 +1,22 @@
 package org.airsonic.player.security;
 
-import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 
 import java.util.Collection;
 
-public class JWTAuthenticationToken extends AbstractAuthenticationToken {
+public class JWTAuthenticationToken extends UsernamePasswordAuthenticationToken {
 
-    private final String token;
     private String requestedPath;
 
-    public static final String USERNAME_ANONYMOUS = "anonymous";
-
-    public JWTAuthenticationToken(Collection<? extends GrantedAuthority> authorities, String token, String requestedPath) {
-        super(authorities);
-        this.token = token;
+    public JWTAuthenticationToken(Object principal, Object credentials, String requestedPath) {
+        super(principal, credentials);
         this.requestedPath = requestedPath;
     }
 
-    @Override
-    public Object getCredentials() {
-        return token;
-    }
-
-    @Override
-    public Object getPrincipal() {
-        return USERNAME_ANONYMOUS;
+    public JWTAuthenticationToken(Object principal, Object credentials, String requestedPath, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+        this.requestedPath = requestedPath;
     }
 
     public String getRequestedPath() {

--- a/airsonic-main/src/main/java/org/airsonic/player/security/JWTRequestParameterProcessingFilter.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/JWTRequestParameterProcessingFilter.java
@@ -9,7 +9,6 @@ import org.springframework.security.authentication.AuthenticationServiceExceptio
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PlayQueueService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PlayQueueService.java
@@ -554,9 +554,8 @@ public class PlayQueueService {
             String streamUrl = url + "stream?player=" + player.getId() + "&id=" + file.getId();
             String coverArtUrl = url + "coverArt.view?id=" + file.getId();
 
-            String remoteStreamUrl = jwtSecurityService
-                    .addJWTToken(url + "ext/stream?player=" + player.getId() + "&id=" + file.getId());
-            String remoteCoverArtUrl = jwtSecurityService.addJWTToken(url + "ext/coverArt.view?id=" + file.getId());
+            String remoteStreamUrl = jwtSecurityService.addJWTToken(player.getUsername(), url + "ext/stream?player=" + player.getId() + "&id=" + file.getId());
+            String remoteCoverArtUrl = jwtSecurityService.addJWTToken(player.getUsername(), url + "ext/coverArt.view?id=" + file.getId());
 
             boolean starred = mediaFileService.getMediaFileStarredDate(file.getId(), player.getUsername()) != null;
             entries.add(new PlayQueueInfo.Entry(file.getId(), file.getTrackNumber(), file.getTitle(), file.getArtist(),

--- a/airsonic-main/src/main/java/org/airsonic/player/service/ShareService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/ShareService.java
@@ -124,7 +124,7 @@ public class ShareService {
 
     public String getShareUrl(HttpServletRequest request, Share share) {
         String shareUrl = NetworkService.getBaseUrl(request) + "ext/share/" + share.getName();
-        return jwtSecurityService.addJWTToken(UriComponentsBuilder.fromUriString(shareUrl), share.getExpires()).build().toUriString();
+        return jwtSecurityService.addJWTToken(JWTSecurityService.USERNAME_ANONYMOUS, UriComponentsBuilder.fromUriString(shareUrl), share.getExpires()).build().toUriString();
     }
 
     public void setSecurityService(SecurityService securityService) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/AlbumUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/AlbumUpnpProcessor.java
@@ -25,6 +25,7 @@ import org.airsonic.player.domain.Album;
 import org.airsonic.player.domain.CoverArtScheme;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MusicFolder;
+import org.airsonic.player.service.JWTSecurityService;
 import org.airsonic.player.service.SearchService;
 import org.fourthline.cling.support.model.BrowseResult;
 import org.fourthline.cling.support.model.DIDLContent;
@@ -146,7 +147,7 @@ public class AlbumUpnpProcessor extends UpnpContentProcessor <Album, MediaFile> 
     }
 
     public URI getAlbumArtURI(int albumId) {
-        return getDispatcher().getJwtSecurityService().addJWTToken(UriComponentsBuilder.fromUriString(getDispatcher().getBaseUrl() + "/ext/coverArt.view").queryParam("id", albumId).queryParam("size", CoverArtScheme.LARGE.getSize())).build().encode().toUri();
+        return getDispatcher().getJwtSecurityService().addJWTToken(JWTSecurityService.USERNAME_ANONYMOUS, UriComponentsBuilder.fromUriString(getDispatcher().getBaseUrl() + "/ext/coverArt.view").queryParam("id", albumId).queryParam("size", CoverArtScheme.LARGE.getSize())).build().encode().toUri();
     }
 
     public PersonWithRole[] getAlbumArtists(String artist) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/CustomContentDirectory.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/CustomContentDirectory.java
@@ -72,7 +72,7 @@ public abstract class CustomContentDirectory extends AbstractContentDirectorySer
             builder.queryParam("format", TranscodingService.FORMAT_RAW);
         }
 
-        jwtSecurityService.addJWTToken(builder);
+        jwtSecurityService.addJWTToken(JWTSecurityService.USERNAME_ANONYMOUS, builder);
 
         String url = builder.toUriString();
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/DispatchingContentDirectory.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/DispatchingContentDirectory.java
@@ -196,7 +196,7 @@ public class DispatchingContentDirectory extends CustomContentDirectory {
     }
 
     public URI getAlbumArtUrl(int id) {
-        return jwtSecurityService.addJWTToken(UriComponentsBuilder.fromUriString(getBaseUrl() + "/ext/coverArt.view").queryParam("id", id).queryParam("size", CoverArtScheme.LARGE.getSize())).build().encode().toUri();
+        return jwtSecurityService.addJWTToken(JWTSecurityService.USERNAME_ANONYMOUS, UriComponentsBuilder.fromUriString(getBaseUrl() + "/ext/coverArt.view").queryParam("id", id).queryParam("size", CoverArtScheme.LARGE.getSize())).build().encode().toUri();
     }
 
     public PlaylistUpnpProcessor getPlaylistProcessor() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/FolderBasedContentDirectory.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/FolderBasedContentDirectory.java
@@ -20,6 +20,7 @@
 package org.airsonic.player.service.upnp;
 
 import org.airsonic.player.domain.*;
+import org.airsonic.player.service.JWTSecurityService;
 import org.airsonic.player.service.MediaFileService;
 import org.airsonic.player.service.PlaylistService;
 import org.airsonic.player.service.search.IndexManager;
@@ -269,7 +270,7 @@ public class FolderBasedContentDirectory extends CustomContentDirectory {
     }
 
     private URI getAlbumArtUrl(MediaFile album) {
-        return jwtSecurityService.addJWTToken(UriComponentsBuilder.fromUriString(getBaseUrl() + "/ext/coverArt.view")
+        return jwtSecurityService.addJWTToken(JWTSecurityService.USERNAME_ANONYMOUS, UriComponentsBuilder.fromUriString(getBaseUrl() + "/ext/coverArt.view")
                 .queryParam("id", album.getId())
                 .queryParam("size", CoverArtScheme.LARGE.getSize()))
                 .build()

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -33,7 +33,7 @@
 
 <script type="text/javascript" language="javascript">
     "use strict";
-    
+
     /** Toggle between <a> and <span> in order to disable play queue action buttons */
     $.fn.toggleLink = function(newState) {
         $(this).each(function(ix, elt) {
@@ -67,7 +67,7 @@
             return true;
         });
     };
-    
+
     var playQueue = {
         // Changed when player is changed
         player: {},
@@ -85,6 +85,9 @@
 
         // Is autorepeat enabled?
         repeatStatus: 'OFF',
+
+        // Play status on the server
+        playStatus: 'PLAYING',
 
         // Is the "shuffle radio" playing? (More > Shuffle Radio)
         shuffleRadioEnabled: false,
@@ -565,20 +568,20 @@
             }
         },
 
-        playQueuePlayStatusCallback(status) {
+        playQueuePlayStatusCallback(status, nonWebOnly) {
+            this.playStatus = status;
             if (status == "PLAYING") {
                 $("#audioStart").hide();
                 $("#audioStop").show();
-                if (this.CastPlayer.castSession) {
+                if (this.CastPlayer.castSession && !nonWebOnly) {
                     this.CastPlayer.playCast();
-                } else if (this.player.tech == 'WEB') {
+                } else if (this.player.tech == 'WEB' && !nonWebOnly) {
                     if (this.audioPlayer.src) {
                         this.audioPlayer.play();  // Resume playing if the player was paused
                     } else {
                         this.onSkip(0);  // Start the first track if the player was not yet loaded
                     }
-                } else if (status != this.player.playStatus) {
-                    this.player.playStatus = status;
+                } else {
                     if (this.player.tech == 'JAVA_JUKEBOX') {
                         JavaJukeBox.javaJukeboxStartCallback();
                     }
@@ -586,12 +589,11 @@
             } else {
                 $("#audioStop").hide();
                 $("#audioStart").show();
-                if (this.CastPlayer.castSession) {
+                if (this.CastPlayer.castSession && !nonWebOnly) {
                     this.CastPlayer.pauseCast();
-                } else if (this.player.tech == 'WEB') {
+                } else if (this.player.tech == 'WEB' && !nonWebOnly) {
                     this.audioPlayer.pause();
-                } else if (status != this.player.playStatus) {
-                    this.player.playStatus = status;
+                } else {
                     if (this.player.tech == 'JAVA_JUKEBOX') {
                         JavaJukeBox.javaJukeboxStopCallback();
                     }
@@ -893,7 +895,7 @@
             }
 
             this.playQueueRepeatStatusCallback(playQueue.repeatStatus);
-            this.playQueuePlayStatusCallback(playQueue.playStatus);
+            this.playQueuePlayStatusCallback(playQueue.playStatus, true);
 
             // download m3u for external player only once at the beginning, every subsequent change is just reflected on the server
             // download m3u for external with playlist player every time the playlist changes

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -394,7 +394,7 @@
                 };
                 //one-time
                 pq.playerSpecificCallbacks['/app/playqueues/' + this.player.id + '/get'] = function(msg) {
-                    pq.playQueueCallback(JSON.parse(msg.body));
+                    pq.playQueueCallback(JSON.parse(msg.body), true);
                 };
 
                 top.StompClient.subscribe("playQueue.jsp", pq.playerSpecificCallbacks);
@@ -581,8 +581,6 @@
                     this.player.playStatus = status;
                     if (this.player.tech == 'JAVA_JUKEBOX') {
                         JavaJukeBox.javaJukeboxStartCallback();
-                    } else if (this.player.tech == 'EXTERNAL' || this.player.tech == 'EXTERNAL_WITH_PLAYLIST') {
-                        parent.frames.main.location.href="play.m3u?";
                     }
                 }
             } else {
@@ -883,7 +881,7 @@
             }
         },
 
-        playQueueCallback(playQueue) {
+        playQueueCallback(playQueue, initial) {
             this.songs = playQueue.entries;
             this.shuffleRadioEnabled = playQueue.shuffleRadioEnabled;
             this.internetRadioEnabled = playQueue.internetRadioEnabled;
@@ -896,6 +894,12 @@
 
             this.playQueueRepeatStatusCallback(playQueue.repeatStatus);
             this.playQueuePlayStatusCallback(playQueue.playStatus);
+
+            // download m3u for external player only once at the beginning, every subsequent change is just reflected on the server
+            // download m3u for external with playlist player every time the playlist changes
+            if ((this.player.tech == 'EXTERNAL' && initial) || this.player.tech == 'EXTERNAL_WITH_PLAYLIST') {
+                parent.frames.main.location.href="play.m3u?";
+            }
 
             // Disable some UI items if internet radio is playing
             $("select#moreActions #loadPlayQueue").prop("disabled", this.internetRadioEnabled);

--- a/airsonic-main/src/test/java/org/airsonic/player/service/JWTSecurityServiceTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/JWTSecurityServiceTest.java
@@ -42,12 +42,13 @@ public class JWTSecurityServiceTest {
     @Test
     public void addJWTToken() {
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(uriString);
-        String actualUri = service.addJWTToken(builder).build().toUriString();
+        String actualUri = service.addJWTToken("xyz", builder).build().toUriString();
         String jwtToken = UriComponentsBuilder.fromUriString(actualUri).build().getQueryParams().getFirst(
                 JWTSecurityService.JWT_PARAM_NAME);
         DecodedJWT verify = verifier.verify(jwtToken);
         Claim claim = verify.getClaim(JWTSecurityService.CLAIM_PATH);
         assertEquals(expectedClaimString, claim.asString());
+        assertEquals("xyz", verify.getSubject());
     }
 
     private SettingsService settingsWithKey(String jwtKey) {


### PR DESCRIPTION
This fixes the external Playlist bug #174, and makes some changes to the JWTs to allow playing via external players:
- The expected behavior is:
  - Download an m3u at player initialization if player is an external player (EXTERNAL_WITH_PLAYLIST or EXTERNAL)
    - No need to press play/pause
  - Download an m3u every time the playlist changes after initialization if the player is an EXTERNAL_WITH_PLAYLIST player (the m3u needs to be updated to reflect the new songs added)
    - No need to download it for EXTERNAL because the original m3u should continue working (only has reference to the player and the playqueue changes are reflected on the server, not in the m3u)
  - We can switch to downloading with play/pause button (as before) later if it generates a large number of m3us for EXTERNAL_WITH_PLAYLIST and there is a lot of complaining, but for now this is the desired (or, at least, intended) behavior
- JWTs generated for logging in (with external players and really anything) now actually embed a subject (username) to sign in as that user.  More details in commit https://github.com/airsonic-advanced/airsonic-advanced/commit/7667547359048a37772901e88c530fc31ff9022b. This is done to fix a bug where the generated playlist is not playable due to the following scenario:
  - User A generates m3u for Player 1 and signs it with JWT
  - User A tries to play the m3u (contains player id = 1)
    - JWT signed in as 'anonymous'
    - The stream controller looks for player id = 1 and finds it
    - The player user (A) is then matched to the logged in user (anonymous) and fails the match
    - The player is rejected and instead a new player (2) is created, with an empty playqueue
    - The new player is then played in the external playlist (with an empty playqueue)
- Note that the above behavior is actually relied on for some scenarios like Sharing where if multiple Shares share the same player id, they would overwrite each others playqueues
  - Shared playlist generated for user A with Guest player and signed with anonymous JWT
  - Someone tries to play it:
    - JWT signed in as 'anonymous' and Guest player have a mismatched username thus guaranteeing a new player is created and new files added to it
- The playstatus of the server is also kept track of on the web client