### PR TITLE
Set top panel iframe height via javascript

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -16,11 +16,9 @@
         }
         .main-navigation {
             width: 100%;
-            height: 0%;
-            flex: 10%;
         }
         .lower {
-            flex: 90%;
+            flex: 100%;
             display: flex;
             flex-direction: row;
             height: 100%;
@@ -64,7 +62,7 @@
 
 <body class="bgcolor2" style="height: 100%; margin: 0">
     <div class="entire-panel">
-        <iframe id="upper" name="upper" src="top.view?" class="bgcolor2 main-navigation"></iframe>
+        <iframe id="upper" name="upper" scrolling="no" src="top.view?" onload="this.style.height=(this.contentWindow.document.body.clientHeight+15)+'px';" class="bgcolor2 main-navigation"></iframe>
 
         <div class="lower">
             <div class="bgcolor2 left-nav-container" ${!model.showSideBar ? "style='display: none;'" : ""}>


### PR DESCRIPTION
The top panel remains an iframe (hasn't been converted yet).

This poses layout problems, especially since it is the first element in the layout. Because the iframe contents haven't loaded yet, the iframe height is set by the useragent to be 150px. Since that is the initial basis for flex, it goes from there and stays at that height.

The approach here is to wait for the contents of the iframe to load and then set the iframe height forcibly afterwards via javascript. This means we can take it out of the flex equation altogether, so the bottom panel effectively flexes to take the rest of the space.

