### PR TITLE
Fix two dialog boxes appearing when appending to playlists

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/mediaMain.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/mediaMain.jsp
@@ -794,11 +794,18 @@
             filesTable.rows().deselect();
         }
     }
+    // need to keep track if a request was sent because plaQueue may also send a request
+    var awaitingAppendPlaylistRequest = false;
     function onAppendPlaylist() {
+        awaitingAppendPlaylistRequest = true;
         // retrieve writable lists so we can open dialog to ask user which playlist to append to
         top.StompClient.send("/app/playlists/writable", "");
     }
     function playlistSelectionCallback(playlists) {
+        if (!awaitingAppendPlaylistRequest) {
+            return;
+        }
+        awaitingAppendPlaylistRequest = false;
         $("#dialog-select-playlist-list").empty();
         for (var i = 0; i < playlists.length; i++) {
             var playlist = playlists[i];

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -835,11 +835,18 @@
         onSavePlaylist() {
             top.StompClient.send("/app/playlists/create/playqueue", this.player.id);
         },
+        // need to keep track if a request was sent because mediaMain may also send a request
+        awaitingAppendPlaylistRequest: false,
         onAppendPlaylist() {
+            this.awaitingAppendPlaylistRequest = true;
             // retrieve writable lists so we can open dialog to ask user which playlist to append to
             top.StompClient.send("/app/playlists/writable", "");
         },
         playlistSelectionCallback(playlists) {
+            if (!this.awaitingAppendPlaylistRequest) {
+                return;
+            }
+            this.awaitingAppendPlaylistRequest = false;
             $("#dialog-select-playlist-list").empty();
             var pq = this;
             for (var i = 0; i < playlists.length; i++) {


### PR DESCRIPTION
Each owner page keeps track of whether it sent a request. On callback, the owner checks if it's waiting for a callback, and executes if it is, otherwise it ignores the request. playQueue and mediaMain are the two owners in this issue.

Fixes #203 