### PR TITLE
Fix bug when trying to connect with t+s and no encoder id is found

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
@@ -138,7 +138,7 @@ public class GlobalSecurityConfig extends GlobalAuthenticationConfigurerAdapter 
         ENCODERS.put("encrypted-AES-GCM", encoder);
         ENCODERS.put("encrypted-AES-GCM" + SALT_TOKEN_MECHANISM_SPECIALIZATION, new SaltedTokenPasswordEncoder(encoder));
 
-        return new DelegatingPasswordEncoder(settingsService.getNonDecodablePasswordEncoder(), ENCODERS) {
+        DelegatingPasswordEncoder pEncoder = new DelegatingPasswordEncoder(settingsService.getNonDecodablePasswordEncoder(), ENCODERS) {
             @Override
             public boolean upgradeEncoding(String prefixEncodedPassword) {
                 PasswordEncoder encoder = ENCODERS.get(StringUtils.substringBetween(prefixEncodedPassword, "{", "}"));
@@ -149,6 +149,20 @@ public class GlobalSecurityConfig extends GlobalAuthenticationConfigurerAdapter 
                 return false;
             }
         };
+
+        pEncoder.setDefaultPasswordEncoderForMatches(new PasswordEncoder() {
+            @Override
+            public boolean matches(CharSequence rawPassword, String encodedPassword) {
+                return false;
+            }
+
+            @Override
+            public String encode(CharSequence rawPassword) {
+                return null;
+            }
+        });
+
+        return pEncoder;
     }
 
     @EventListener


### PR DESCRIPTION
Spring changed implementations and was now throwing an exception instead of just refusing to match if DelegatingPasswordEncoder didn't find an id.

Example: t+s auth mechanism when encounters a bcrypt cred to match against, will issue a match against '{bcryptsalttoken}storedcred', which doesn't exist. Instead of throwing an exception, the implementation needs to say no-match so it can move on to the next cred.

Fixes #212 