### PR TITLE
Fix doublebinding keyboard shortcuts

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=utf-8" pageEncoding="utf-8"%>
-<%@ include file="head.jsp" %>
+<%@ include file="include.jsp" %>
 <%@ include file="jquery.jsp" %>
 <%@ include file="table.jsp" %>
 <script type="text/javascript" src="<c:url value='/script/utils.js'/>"></script>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/table.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/table.jsp
@@ -8,6 +8,7 @@
         display: none;
     }
 </style>
+<c:set var="styleSheet"><spring:theme code="styleSheet"/></c:set>
 <link rel="stylesheet" href="<c:url value='/${styleSheet}'/>" type="text/css">
 <script type="text/javascript" src="<c:url value='/script/DataTables/datatables.min.js'/>"></script>
 <script type="text/javascript" src="<c:url value='/script/DataTables/row.show.js'/>"></script>


### PR DESCRIPTION
playqueue and index both call head.jsp which imports a js file for keyboard binding. this is problematic because then keyboard bindings are bound twice. now playqueue only calls include.jsp (to import jsp related things so it can compile)

Fixes #217 