### PR TITLE
Make all table row line heights to be 100% instead of 190%

### DIFF
--- a/airsonic-main/src/main/webapp/style/default-without-mediaelement.css
+++ b/airsonic-main/src/main/webapp/style/default-without-mediaelement.css
@@ -332,7 +332,7 @@ table.indent {
 }
 
 table.music {
-    line-height: 190%;
+    line-height: 100%;
     border-collapse:collapse;
     white-space:nowrap;
     width: 100%;


### PR DESCRIPTION
Makes playqueue line height the same as playlist line height.

Fixes #229