### PR TITLE
Update in batches because Postgres wire cannot handle large number of params

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/dao/AbstractDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/AbstractDao.java
@@ -109,13 +109,13 @@ public class AbstractDao {
         int batchSize = 30000 / batchArgs.stream().findAny().map(x -> x.length).orElse(1);
         LOG.trace("Executing query: [{}]", sql);
         int[][] result = getJdbcTemplate().batchUpdate(sql,
-                batchArgs.parallelStream().map(AbstractDao::convertToDBTypes).collect(Collectors.toList()),
-                batchSize,
-                (ps, args) -> {
-                    for (int i = 0; i < args.length; i++) {
-                        ps.setObject(i + 1, args[i]);
-                    }
-                });
+            batchArgs.parallelStream().map(AbstractDao::convertToDBTypes).collect(Collectors.toList()),
+            batchSize,
+            (ps, args) -> {
+                for (int i = 0; i < args.length; i++) {
+                    ps.setObject(i + 1, args[i]);
+                }
+            });
         int tally = Arrays.stream(result).flatMapToInt(Arrays::stream).sum();
         LOG.trace("Updated {} rows", tally);
         log(sql, t);

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/AbstractDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/AbstractDao.java
@@ -31,6 +31,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,7 +72,7 @@ public class AbstractDao {
 
     protected static Object[] convertToDBTypes(Object[] args) {
         return args == null ? null : Stream.of(args)
-                .map(x -> (Object) ((x instanceof Instant) ? Timestamp.from((Instant) x) : x))
+                .map(x -> ((x instanceof Instant) ? Timestamp.from((Instant) x) : x))
                 .collect(Collectors.toList())
                 .toArray();
     }
@@ -100,6 +101,25 @@ public class AbstractDao {
         LOG.trace("Updated {} rows", result);
         log(sql, t);
         return result;
+    }
+
+    protected int batchedUpdate(String sql, Collection<Object[]> batchArgs) {
+        long t = System.nanoTime();
+        // used to get around postgres's wire limit when sending a large number of params
+        int batchSize = 30000 / batchArgs.stream().findAny().map(x -> x.length).orElse(1);
+        LOG.trace("Executing query: [{}]", sql);
+        int[][] result = getJdbcTemplate().batchUpdate(sql,
+                batchArgs.parallelStream().map(AbstractDao::convertToDBTypes).collect(Collectors.toList()),
+                batchSize,
+                (ps, args) -> {
+                    for (int i = 0; i < args.length; i++) {
+                        ps.setObject(i + 1, args[i]);
+                    }
+                });
+        int tally = Arrays.stream(result).flatMapToInt(Arrays::stream).sum();
+        LOG.trace("Updated {} rows", tally);
+        log(sql, t);
+        return tally;
     }
 
     private void log(String sql, long startTimeNano) {

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
@@ -19,7 +19,6 @@
  */
 package org.airsonic.player.dao;
 
-import com.google.common.collect.ImmutableMap;
 import org.airsonic.player.domain.Genre;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MusicFolder;
@@ -37,6 +36,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Provides database services for media files.
@@ -207,12 +207,13 @@ public class MediaFileDao extends AbstractDao {
     }
 
     public void deleteMediaFile(String path) {
-        update("update media_file set present=false, children_last_updated=? where path=?", Instant.ofEpochMilli(1), path);
+        deleteMediaFiles(Collections.singletonList(path));
     }
 
     public void deleteMediaFiles(Collection<String> paths) {
         if (!paths.isEmpty()) {
-            namedUpdate("update media_file set present=false, children_last_updated=:updatedate where path in (:paths)", ImmutableMap.of("updatedate", Instant.ofEpochMilli(1), "paths", paths));
+            batchedUpdate("update media_file set present=false, children_last_updated=? where path=?",
+                    paths.parallelStream().map(p -> new Object[] { Instant.ofEpochMilli(1), p }).collect(Collectors.toList()));
         }
     }
 
@@ -221,12 +222,17 @@ public class MediaFileDao extends AbstractDao {
         return query("select " + GENRE_COLUMNS + " from genre order by " + orderBy + " desc", genreRowMapper);
     }
 
-    public void updateGenres(List<Genre> genres) {
+    public boolean updateGenres(List<Genre> genres) {
         update("delete from genre");
-        for (Genre genre : genres) {
-            update("insert into genre(" + GENRE_COLUMNS + ") values(?, ?, ?)",
-                   genre.getName(), genre.getSongCount(), genre.getAlbumCount());
+        if (!genres.isEmpty()) {
+            return batchedUpdate("insert into genre(" + GENRE_COLUMNS + ") values(?, ?, ?)",
+                    genres.parallelStream()
+                            .map(genre -> new Object[] { genre.getName(), genre.getSongCount(), genre.getAlbumCount() })
+                            .collect(Collectors.toList()))
+                == genres.size();
         }
+
+        return true;
     }
 
     /**
@@ -657,14 +663,18 @@ public class MediaFileDao extends AbstractDao {
         return queryForInstant("select created from starred_media_file where media_file_id=? and username=?", null, id, username);
     }
 
-    public void markPresent(String path, Instant lastScanned) {
-        update("update media_file set present=?, last_scanned = ? where path=?", true, lastScanned, path);
+    public boolean markPresent(String path, Instant lastScanned) {
+        return markPresent(Collections.singletonList(path), lastScanned);
     }
 
-    public void markPresent(Collection<String> paths, Instant lastScanned) {
+    public boolean markPresent(Collection<String> paths, Instant lastScanned) {
         if (!paths.isEmpty()) {
-            namedUpdate("update media_file set present=true, last_scanned = :lastScanned where path in (:paths)", ImmutableMap.of("lastScanned", lastScanned, "paths", paths));
+            return batchedUpdate("update media_file set present=true, last_scanned = ? where path = ?",
+                    paths.parallelStream().map(p -> new Object[] { lastScanned, p }).collect(Collectors.toList()))
+                == paths.size();
         }
+
+        return true;
     }
 
     public void markNonPresent(Instant lastScanned) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -269,9 +269,9 @@ public class MediaScannerService {
             CompletableFuture<Void> genrePersistence = CompletableFuture
                     .runAsync(() -> {
                         LOG.info("Updating genres");
-                        mediaFileDao.updateGenres(genres.getGenres());
-                    }, pool)
-                    .thenRunAsync(() -> LOG.info("Genre persistence complete"), pool);
+                        boolean genresSuccessful = mediaFileDao.updateGenres(genres.getGenres());
+                        LOG.info("Genre persistence successfully complete: {}", genresSuccessful);
+                    }, pool);
 
             CompletableFuture.allOf(albumPersistence, artistPersistence, mediaFilePersistence, genrePersistence).join();
 


### PR DESCRIPTION
Postgres driver can only send a certain number of params over the wire in one go (32767).
This poses issues for `IN` statements with a large number of params (such as a large number of media files being marked present simultaneously).
Base airsonic updated files one-by-one and thus does not come across this issue.

This fix introduces batchedUpdates so updates are still sent en masse but in batched statement form in batches that are below the postgres limit (even if the db isn't postgres). Those drivers that do not support batched updates (maybe HSQLDB 1.8?) will send statements over one by one.

The overall outcome is that the statement won't yield exceptions for postgres for a large number of params, BUT it will most certainly be slower than a large IN query because the query planner won't be able to optimize for all the args together, instead will see each one by one. The degree of slowness is also additionally compounded if the driver does not support batch updates so the updates go over the wire one by one.

An additional improvement may be to break up chunks of args and still send them in IN statements, but the degree of improvement needs to be measured. This was implemented in the second commit.

For more info, a sample issue is here:
https://github.com/jOOQ/jOOQ/issues/5701

The exception is seen in issue #202 and this PR should fix it.