### PR TITLE
Docker puid/pgid

### DIFF
--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -3,12 +3,13 @@ FROM adoptopenjdk:14-jre-hotspot
 LABEL description="Airsonic-Advanced is a free, web-based media streamer, providing ubiquitous access to your music." \
       url="https://github.com/airsonic-advanced/airsonic-advanced"
 
-ENV AIRSONIC_PORT=4040 AIRSONIC_DIR=/var CONTEXT_PATH=/ UPNP_PORT=4041
+ENV AIRSONIC_PORT=4040 AIRSONIC_DIR=/var CONTEXT_PATH=/ UPNP_PORT=4041 PUID=0 PGID=0
 
 WORKDIR $AIRSONIC_DIR
 
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /usr/local/bin/tini
 RUN chmod +x /usr/local/bin/tini
+
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
     add-apt-repository -y ppa:jonathonf/ffmpeg-4 && \
@@ -21,7 +22,6 @@ RUN apt-get update && \
                        ttf-dejavu
 
 COPY run.sh /usr/local/bin/run.sh
-
 RUN chmod +x /usr/local/bin/run.sh
 
 COPY target/dependency/airsonic-main.war airsonic.war
@@ -31,6 +31,8 @@ EXPOSE $AIRSONIC_PORT
 # Default DLNA/UPnP ports
 EXPOSE $UPNP_PORT
 EXPOSE 1900/udp
+
+USER $PUID:$PGID
 
 VOLUME $AIRSONIC_DIR/airsonic $AIRSONIC_DIR/music $AIRSONIC_DIR/playlists $AIRSONIC_DIR/podcasts
 

--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -19,10 +19,13 @@ RUN apt-get update && \
                        x265 \
                        lame \
                        bash \
-                       ttf-dejavu
+                       ttf-dejavu \
+                       gosu
 
 COPY run.sh /usr/local/bin/run.sh
 RUN chmod +x /usr/local/bin/run.sh
+COPY entry.sh /usr/local/bin/entry.sh
+RUN chmod +x /usr/local/bin/entry.sh
 
 COPY target/dependency/airsonic-main.war airsonic.war
 
@@ -32,10 +35,10 @@ EXPOSE $AIRSONIC_PORT
 EXPOSE $UPNP_PORT
 EXPOSE 1900/udp
 
-USER $PUID:$PGID
+USER ${PUID}:${PGID}
 
 VOLUME $AIRSONIC_DIR/airsonic $AIRSONIC_DIR/music $AIRSONIC_DIR/playlists $AIRSONIC_DIR/podcasts
 
 HEALTHCHECK --interval=15s --timeout=3s CMD curl -f http://localhost:"$AIRSONIC_PORT""$CONTEXT_PATH"rest/ping || false
 
-ENTRYPOINT ["tini", "--", "run.sh"]
+ENTRYPOINT ["tini", "--", "entry.sh"]

--- a/install/docker/entry.sh
+++ b/install/docker/entry.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+ue=$(id -u)
+echo "Docker USER id: $ue"
+echo "Docker PUID env: $PUID"
+ge=$(id -g)
+echo "Docker USER group: $ge"
+echo "Docker PGID env: $PGID"
+if [ $ue != '0' ] || [ $ge != '0' ]; then
+  # specified from USER directive, run as is
+  run.sh "$@"
+else
+  # No USER specified, guaranteed to be root
+  ge=$(getent group $PGID | cut -d":" -f1)
+  gn=${ge:-ag}
+  if [ $gn == 'ag' ]; then
+    # group doesn't exist, create it
+    groupadd -r -g $PGID ag
+  fi
+  ue=$(getent passwd $PUID | cut -d":" -f1)
+  un=${ue:-au}
+  if [ $un == 'au' ]; then
+    # user doesn't exist, create it
+    useradd -r -u $PUID au
+  fi
+  # add user to group
+  usermod -g $gn $un
+  # execute as user
+  exec gosu $un run.sh "$@"
+fi

--- a/install/docker/run.sh
+++ b/install/docker/run.sh
@@ -2,13 +2,17 @@
 
 set -e
 
+echo "Process will run as:"
+echo "User: $(id -u)"
+echo "Group: $(id -g)"
 mkdir -p $AIRSONIC_DIR/airsonic/transcode
 ln -fs /usr/bin/ffmpeg $AIRSONIC_DIR/airsonic/transcode/ffmpeg
 ln -fs /usr/bin/lame $AIRSONIC_DIR/airsonic/transcode/lame
 java --version
+echo "JAVA_OPTS=$JAVA_OPTS"
 /usr/bin/ffmpeg -version
 curl --version
-echo "PATH:$PATH"
+echo "PATH=$PATH"
 
 if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
 


### PR DESCRIPTION
Combines 2 mechanisms that exist to specify the user/group to run the container. User/Group may be specified using:
- `--user` param in the docker run invocation
- `PUID` or `PGID` environment params provided to the container

The first takes precedence over the second. If neither is specified, the container runs as root (as before).

Note that the specified user/group should have write/read privileges on the volumes that are being mounted (particularly the data volume where symlinks to the transcodes/db are made)

Examples:
- `docker run --user 787:121 -v data:/var/data airsonicadvanced:airsonic-advanced:latest`
  - Runs and creates files as user 781, group 121
- `docker run --user 787 -v data:/var/data airsonicadvanced:airsonic-advanced:latest`
  - Runs and creates files as user 781, group 0 (root
- `docker run --user :121 -v data:/var/data airsonicadvanced:airsonic-advanced:latest`
  - Runs and creates files as user 0 (root), group 121
- `docker run -e PUID=787 -e PGID=121 -v data:/var/data airsonicadvanced:airsonic-advanced:latest`
  - Runs and creates files as user 787, group 121
- `docker run -e PUID=787 -v data:/var/data airsonicadvanced:airsonic-advanced:latest`
  - Runs and creates files as user 787, group 0 (root)
- `docker run -e PGID=121 -v data:/var/data airsonicadvanced:airsonic-advanced:latest`
  - Runs and creates files as user 0 (root), group 121
- `docker run -e PUID=787 -e PGID=121 --user 323 -v data:/var/data airsonicadvanced:airsonic-advanced:latest`
  - Runs and creates files as user 323, group 0 (`--user` takes precedence over `PUID/PGID` mechanism)
- `docker run -v data:/var/data airsonicadvanced:airsonic-advanced:latest`
  - Runs and creates files as user 0, group 0 (both root)

By request, and fixes #157 