### PR TITLE
Remove selections after action in play queue

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playQueue.jsp
@@ -891,6 +891,7 @@
                 // change page
                 top.main.location.href = "playlist.view?id=" + playlistId;
             }
+            this.selectAll(false);
             $().toastmessage("showSuccessToast", toastMsg);
         },
 
@@ -1067,6 +1068,7 @@
                 this.onRemoveSelected();
             } else if (id == "download" && selectedIndexes != "") {
                 location.href = "download.view?player=" + this.player.id + "&" + selectedIndexes;
+                this.selectAll(false);
             } else if (id == "appendPlaylist" && selectedIndexes != "") {
                 this.onAppendPlaylist();
             }


### PR DESCRIPTION
When I selected some tracks in the play queue and used the action "Add to playlist" the tracks were still selected after this action had been finished. Usually I'll add some more tracks to a playlist later, so I always had to remove the selection manually after adding them to the playlist. If I forgot this I ended up having some tracks twice (or more) in my playlist.

I think the process is as follow:
1. User likes to to an action with his tracks
2. User selects some tracks
3. User does the action
4. As the action is finished now, he won't need the selection anymore

So I made this pull request to remove selection, after the action in the play queue has been finished. To make it consistent I also removed the selection after downloading. For removal it wasn't needed, as there's nothing to deselect anymore...