### PR TITLE
Fix download issue of files in album view

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -205,7 +205,7 @@ public class DownloadController {
                             settingsService.getDownloadBitrateLimiter(),
                             statusSupplier,
                             statusCloser,
-                            (input, status) -> {}),
+                        (input, status) -> {}),
                     path.getFileName().toString(),
                     file.getFileSize(),
                     changed);

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -103,11 +103,11 @@ public class DownloadController {
 
     @GetMapping
     public ResponseEntity<Resource> handleRequest(Principal p,
-                                                  @RequestParam Optional<Integer> id,
-                                                  @RequestParam(required = false) Integer playlist,
-                                                  @RequestParam(required = false) Integer player,
-                                                  @RequestParam(required = false, name = "i") List<Integer> indices,
-                                                  ServletWebRequest swr) throws Exception {
+            @RequestParam Optional<Integer> id,
+            @RequestParam(required = false) Integer playlist,
+            @RequestParam(required = false) Integer player,
+            @RequestParam(required = false, name = "i") List<Integer> indices,
+            ServletWebRequest swr) throws Exception {
         User user = securityService.getUserByName(p.getName());
         Player transferPlayer = playerService.getPlayer(swr.getRequest(), swr.getResponse(), false, false);
         String defaultDownloadName = null;
@@ -165,8 +165,8 @@ public class DownloadController {
      */
     private static long computeCrc(Path file) throws IOException {
         try (InputStream is = Files.newInputStream(file);
-             BufferedInputStream bis = new BufferedInputStream(is);
-             CheckedInputStream cis = new CheckedInputStream(bis, new CRC32())) {
+            BufferedInputStream bis = new BufferedInputStream(is);
+            CheckedInputStream cis = new CheckedInputStream(bis, new CRC32())) {
             byte[] buf = new byte[8192];
             while ((cis.read(buf)) != -1) {
                 continue;
@@ -181,7 +181,7 @@ public class DownloadController {
     }
 
     private ResponseDTO prepareResponse(List<MediaFile> files, List<Integer> indices,
-                                        Supplier<TransferStatus> statusSupplier, Consumer<TransferStatus> statusCloser, Path... additionalFiles)
+            Supplier<TransferStatus> statusSupplier, Consumer<TransferStatus> statusCloser, Path... additionalFiles)
             throws IOException {
         if (indices == null) {
             indices = IntStream.range(0, files.size()).boxed().collect(Collectors.toList());
@@ -205,8 +205,7 @@ public class DownloadController {
                             settingsService.getDownloadBitrateLimiter(),
                             statusSupplier,
                             statusCloser,
-                            (input, status) -> {
-                            }),
+                            (input, status) -> {}),
                     path.getFileName().toString(),
                     file.getFileSize(),
                     changed);
@@ -242,7 +241,7 @@ public class DownloadController {
                 // start a new thread to feed data in
                 new Thread(() -> {
                     try (PipedOutputStream pout = new PipedOutputStream(pin);
-                         ZipOutputStream zout = new ZipOutputStream(pout)) {
+                        ZipOutputStream zout = new ZipOutputStream(pout)) {
                         zout.setMethod(ZipOutputStream.STORED); // No compression.
                         pathsToZip.stream().forEach(LambdaUtils.uncheckConsumer(f -> {
                             status.setFile(f.getKey());

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -103,11 +103,11 @@ public class DownloadController {
 
     @GetMapping
     public ResponseEntity<Resource> handleRequest(Principal p,
-            @RequestParam Optional<Integer> id,
-            @RequestParam(required = false) Integer playlist,
-            @RequestParam(required = false) Integer player,
-            @RequestParam(required = false, name = "i") List<Integer> indices,
-            ServletWebRequest swr) throws Exception {
+                                                  @RequestParam Optional<Integer> id,
+                                                  @RequestParam(required = false) Integer playlist,
+                                                  @RequestParam(required = false) Integer player,
+                                                  @RequestParam(required = false, name = "i") List<Integer> indices,
+                                                  ServletWebRequest swr) throws Exception {
         User user = securityService.getUserByName(p.getName());
         Player transferPlayer = playerService.getPlayer(swr.getRequest(), swr.getResponse(), false, false);
         String defaultDownloadName = null;
@@ -165,8 +165,8 @@ public class DownloadController {
      */
     private static long computeCrc(Path file) throws IOException {
         try (InputStream is = Files.newInputStream(file);
-                BufferedInputStream bis = new BufferedInputStream(is);
-                CheckedInputStream cis = new CheckedInputStream(bis, new CRC32())) {
+             BufferedInputStream bis = new BufferedInputStream(is);
+             CheckedInputStream cis = new CheckedInputStream(bis, new CRC32())) {
             byte[] buf = new byte[8192];
             while ((cis.read(buf)) != -1) {
                 continue;
@@ -181,7 +181,7 @@ public class DownloadController {
     }
 
     private ResponseDTO prepareResponse(List<MediaFile> files, List<Integer> indices,
-            Supplier<TransferStatus> statusSupplier, Consumer<TransferStatus> statusCloser, Path... additionalFiles)
+                                        Supplier<TransferStatus> statusSupplier, Consumer<TransferStatus> statusCloser, Path... additionalFiles)
             throws IOException {
         if (indices == null) {
             indices = IntStream.range(0, files.size()).boxed().collect(Collectors.toList());
@@ -194,7 +194,7 @@ public class DownloadController {
             return new ResponseDTO(null, "emptyfile.download", 0, -1);
         }
 
-        if (indices.size() == 1 && (additionalFiles == null || additionalFiles.length == 0)) {
+        if (indices.size() == 1 && ((additionalFiles == null || additionalFiles.length == 0) || (additionalFiles.length == 1 && additionalFiles[0] == null))) {
             // single file
             MediaFile file = files.get(indices.get(0));
             Path path = file.getFile();
@@ -205,7 +205,8 @@ public class DownloadController {
                             settingsService.getDownloadBitrateLimiter(),
                             statusSupplier,
                             statusCloser,
-                        (input, status) -> {}),
+                            (input, status) -> {
+                            }),
                     path.getFileName().toString(),
                     file.getFileSize(),
                     changed);
@@ -213,6 +214,7 @@ public class DownloadController {
             // get a list of all paths under the tree, plus their zip names and sizes
             Collection<Pair<Path, Pair<String, Long>>> pathsToZip = Streams
                     .concat(indices.stream().map(i -> files.get(i)).map(x -> x.getFile()), Stream.of(additionalFiles))
+                    .filter(p -> p != null)
                     .flatMap(p -> {
                         Path parent = p.getParent();
                         try (Stream<Path> paths = Files.walk(p)) {
@@ -240,7 +242,7 @@ public class DownloadController {
                 // start a new thread to feed data in
                 new Thread(() -> {
                     try (PipedOutputStream pout = new PipedOutputStream(pin);
-                            ZipOutputStream zout = new ZipOutputStream(pout)) {
+                         ZipOutputStream zout = new ZipOutputStream(pout)) {
                         zout.setMethod(ZipOutputStream.STORED); // No compression.
                         pathsToZip.stream().forEach(LambdaUtils.uncheckConsumer(f -> {
                             status.setFile(f.getKey());


### PR DESCRIPTION
Under Windows 10 with OpenJDK 14, I was not able to do downloads in the view where I browse an album (only download from player queue was working). There was always a 500 error with NullPointer Exception when starting the download. When selecting multiple tracks for download, there was always an additional path which was null.
To filter that I add
`.filter(p -> p != null)`

When downloading a single file it always created a zip file instead of just downloading the file. For that I had to add the following code, additionalFiles had a length of 1 but this element was null.
` || (additionalFiles.length == 1 && additionalFiles[0] == null)`