### PR TITLE
Allow LDAP auth provider a chance at the user auth

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
@@ -102,7 +102,7 @@ public class SecurityService implements UserDetailsService {
         return new UserDetail(
                 username,
                 getCredentials(user.getUsername(), App.AIRSONIC),
-                !user.isLdapAuthenticated(),
+                true,
                 true,
                 true,
                 true,


### PR DESCRIPTION
LDAP auth provider was not getting a chance at authing a user because LDAP enabled user accounts were considered being disabled

Fixes #290 