### PR TITLE
Podcast episodes more actions dropdown

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -103,11 +103,11 @@ public class DownloadController {
 
     @GetMapping
     public ResponseEntity<Resource> handleRequest(Principal p,
-                                                  @RequestParam Optional<Integer> id,
-                                                  @RequestParam(required = false) Integer playlist,
-                                                  @RequestParam(required = false) Integer player,
-                                                  @RequestParam(required = false, name = "i") List<Integer> indices,
-                                                  ServletWebRequest swr) throws Exception {
+            @RequestParam Optional<Integer> id,
+            @RequestParam(required = false) Integer playlist,
+            @RequestParam(required = false) Integer player,
+            @RequestParam(required = false, name = "i") List<Integer> indices,
+            ServletWebRequest swr) throws Exception {
         User user = securityService.getUserByName(p.getName());
         Player transferPlayer = playerService.getPlayer(swr.getRequest(), swr.getResponse(), false, false);
         String defaultDownloadName = null;
@@ -165,8 +165,8 @@ public class DownloadController {
      */
     private static long computeCrc(Path file) throws IOException {
         try (InputStream is = Files.newInputStream(file);
-             BufferedInputStream bis = new BufferedInputStream(is);
-             CheckedInputStream cis = new CheckedInputStream(bis, new CRC32())) {
+            BufferedInputStream bis = new BufferedInputStream(is);
+            CheckedInputStream cis = new CheckedInputStream(bis, new CRC32())) {
             byte[] buf = new byte[8192];
             while ((cis.read(buf)) != -1) {
                 continue;
@@ -205,8 +205,7 @@ public class DownloadController {
                             settingsService.getDownloadBitrateLimiter(),
                             statusSupplier,
                             statusCloser,
-                            (input, status) -> {
-                            }),
+                            (input, status) -> {}),
                     path.getFileName().toString(),
                     file.getFileSize(),
                     changed);
@@ -242,7 +241,7 @@ public class DownloadController {
                 // start a new thread to feed data in
                 new Thread(() -> {
                     try (PipedOutputStream pout = new PipedOutputStream(pin);
-                         ZipOutputStream zout = new ZipOutputStream(pout)) {
+                        ZipOutputStream zout = new ZipOutputStream(pout)) {
                         zout.setMethod(ZipOutputStream.STORED); // No compression.
                         pathsToZip.stream().forEach(LambdaUtils.uncheckConsumer(f -> {
                             status.setFile(f.getKey());

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -103,11 +103,11 @@ public class DownloadController {
 
     @GetMapping
     public ResponseEntity<Resource> handleRequest(Principal p,
-            @RequestParam Optional<Integer> id,
-            @RequestParam(required = false) Integer playlist,
-            @RequestParam(required = false) Integer player,
-            @RequestParam(required = false, name = "i") List<Integer> indices,
-            ServletWebRequest swr) throws Exception {
+                                                  @RequestParam Optional<Integer> id,
+                                                  @RequestParam(required = false) Integer playlist,
+                                                  @RequestParam(required = false) Integer player,
+                                                  @RequestParam(required = false, name = "i") List<Integer> indices,
+                                                  ServletWebRequest swr) throws Exception {
         User user = securityService.getUserByName(p.getName());
         Player transferPlayer = playerService.getPlayer(swr.getRequest(), swr.getResponse(), false, false);
         String defaultDownloadName = null;
@@ -165,8 +165,8 @@ public class DownloadController {
      */
     private static long computeCrc(Path file) throws IOException {
         try (InputStream is = Files.newInputStream(file);
-                BufferedInputStream bis = new BufferedInputStream(is);
-                CheckedInputStream cis = new CheckedInputStream(bis, new CRC32())) {
+             BufferedInputStream bis = new BufferedInputStream(is);
+             CheckedInputStream cis = new CheckedInputStream(bis, new CRC32())) {
             byte[] buf = new byte[8192];
             while ((cis.read(buf)) != -1) {
                 continue;
@@ -195,7 +195,7 @@ public class DownloadController {
         }
 
         if (indices.size() == 1 && (additionalFiles == null || additionalFiles.size() == 0)) {
-            // single file
+		// single file
             MediaFile file = files.get(indices.get(0));
             Path path = file.getFile();
             long changed = file.getChanged() == null ? -1 : file.getChanged().toEpochMilli();
@@ -205,7 +205,8 @@ public class DownloadController {
                             settingsService.getDownloadBitrateLimiter(),
                             statusSupplier,
                             statusCloser,
-                        (input, status) -> {}),
+                            (input, status) -> {
+                            }),
                     path.getFileName().toString(),
                     file.getFileSize(),
                     changed);
@@ -241,7 +242,7 @@ public class DownloadController {
                 // start a new thread to feed data in
                 new Thread(() -> {
                     try (PipedOutputStream pout = new PipedOutputStream(pin);
-                            ZipOutputStream zout = new ZipOutputStream(pout)) {
+                         ZipOutputStream zout = new ZipOutputStream(pout)) {
                         zout.setMethod(ZipOutputStream.STORED); // No compression.
                         pathsToZip.stream().forEach(LambdaUtils.uncheckConsumer(f -> {
                             status.setFile(f.getKey());

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/PodcastChannelController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/PodcastChannelController.java
@@ -53,13 +53,14 @@ public class PodcastChannelController {
 
         Map<String, Object> map = new HashMap<>();
         ModelAndView result = new ModelAndView();
-        result.addObject("model", map);
 
         int channelId = ServletRequestUtils.getRequiredIntParameter(request, "id");
 
         map.put("user", securityService.getCurrentUser(request));
         map.put("channel", podcastService.getChannel(channelId));
         map.put("episodes", podcastService.getEpisodes(channelId));
+
+        result.addObject("model", map);
         return result;
     }
 

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/podcastChannel.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/podcastChannel.jsp
@@ -27,9 +27,9 @@
     <script type="text/javascript" src="<c:url value='/script/utils.js'/>"></script>
     <script type="text/javascript" language="javascript">
         function init() {
-            top.StompClient.subscribe("pdcactChannel.jsp", {
+
+            top.StompClient.subscribe("podcactChannel.jsp", {
                 '/user/queue/playlists/writable': function(msg) {
-                    console.log('playlistSelectionCallback');
                     playlistSelectionCallback(JSON.parse(msg.body));
                 },
                 '/user/queue/playlists/files/append': function(msg) {
@@ -82,10 +82,7 @@
         function appendPlaylist(playlistId) {
             $("#dialog-select-playlist").dialog("close");
 
-            //var mediaFileIds = filesTable.rows({selected:true}).data().map(function(d) { return d.id; }).toArray();
             var mediaFileIds = getSelectedEpisodesMediaId();
-            console.log(mediaFileIds);
-
             top.StompClient.send("/app/playlists/files/append", JSON.stringify({id: playlistId, modifierIds: mediaFileIds}));
         }
 
@@ -208,6 +205,8 @@
     <c:forEach items="${model.episodes}" var="episode" varStatus="i">
 
         <tr>
+            <td class="fit"><input type="checkbox" id="episode${i.index}" value="${episode.id}" mediafileid="${episode.mediaFileId}" /></td>
+
             <c:choose>
                 <c:when test="${empty episode.mediaFileId or episode.status ne 'COMPLETED'}">
                     <td colspan="4"></td>
@@ -222,8 +221,6 @@
                     </c:import>
                 </c:otherwise>
             </c:choose>
-
-            <td class="fit"><input type="checkbox" id="episode${i.index}" value="${episode.id}" mediafileid="${episode.mediaFileId}" /></td>
 
             <td class="truncate">
                 <span title="${episode.title}" class="songTitle">${episode.title}</span>
@@ -267,7 +264,7 @@
 </table>
 
 <select id="moreActions" class="pagetype-dependent type-album type-video" onchange="actionSelected(this.options[selectedIndex].id);" style="margin-bottom:1.0em">
-    <option id="top" selected="selected"><fmt:message key="main.more.selection"/></option>
+    <option id="top" selected="selected"><fmt:message key="playlist.more"/></option>
     <option id="selectAll">&nbsp;&nbsp;<fmt:message key="playlist.more.selectall"/></option>
     <option id="selectNone">&nbsp;&nbsp;<fmt:message key="playlist.more.selectnone"/></option>
     <c:if test="${model.user.downloadRole}">


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/9485516/81910589-7199e700-95cc-11ea-8eb7-cdc3c1239af4.png)

This pull request adds a "More actions..." dropdown to the Podcast Episodes view. It has the same functionalities as the dropdowns in the player queue and the album view. Only the "Share" option is missing. This one was not straight forward to implement. The issue here is, that the external player doesn't have access to the podcast folder.

For that pull request I reused some existing websocket functionalities:
- To get index of the media file in the media folder (needed for the download)
- Playlist handling

If you select some episodes, which are not downloaded yet, you'll get an error toast message for the selected episodes. This text would need to be translated:
![grafik](https://user-images.githubusercontent.com/9485516/81911115-2207eb00-95cd-11ea-95a8-0a6755e3fd63.png)
