### PR TITLE
Remove scollY (height limit) on playlist datatable

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/mediaMain.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/mediaMain.jsp
@@ -274,7 +274,6 @@
             processing: true,
             autoWidth: true,
             scrollCollapse: true,
-            //scrollY: "60vh",
             dom: "<'#filesHeader'><'tableSpacer'>lfrtip",
             select: {
                 style: "multi",

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playlist.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playlist.jsp
@@ -25,7 +25,6 @@
                 processing: true,
                 autoWidth: true,
                 scrollCollapse: true,
-                scrollY: "60vh",
               <c:if test="${model.editAllowed}">
                 rowReorder: {
                     dataSrc: "seq",


### PR DESCRIPTION
The height of the DataTable on the playlist view was limited to a maximum of 60hv. In the album view there is no limit. I found the same setting there, but commented out. So I removed it in both views.
Now the height of the DataTable is now longer limited and only bound to the number chosen in "Show x entries". @randomnicode I'm now defenitly getting what you ment in #274 with the custom height ;-)

With the current release I'm getting two vertical scroll bar in the playlist view (one on the datatable and one in the main iframe), with e.g. "All" selected in "Show x entries" and a long playlist. This issue is getting resolved with this pull request as well. I'm happy tough with just one vertical scroll bar now :-)
Can be reproduced on other sceen resolutions when zooming in with the browser (e.g. 120%+).