### PR TITLE
Smaller size cover art for display

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playlist.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playlist.jsp
@@ -332,7 +332,7 @@
 <div style="float:left;margin-right:1.5em;margin-bottom:1.5em">
 <c:import url="coverArt.jsp">
     <c:param name="playlistId" value="${model.playlist.id}"/>
-    <c:param name="coverArtSize" value="200"/>
+    <c:param name="coverArtSize" value="160"/>
 </c:import>
 </div>
 

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/playlists.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/playlists.jsp
@@ -23,7 +23,7 @@
     <div class="albumThumb">
         <c:import url="coverArt.jsp">
             <c:param name="playlistId" value="${playlist.id}"/>
-            <c:param name="coverArtSize" value="200"/>
+            <c:param name="coverArtSize" value="160"/>
             <c:param name="caption1" value="${fn:escapeXml(playlist.name)}"/>
             <c:param name="caption2" value="${caption2}"/>
             <c:param name="captionCount" value="2"/>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/podcastChannel.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/podcastChannel.jsp
@@ -77,7 +77,7 @@
 <div style="float:left;margin-right:1.5em;margin-bottom:1.5em">
 <c:import url="coverArt.jsp">
     <c:param name="podcastChannelId" value="${model.channel.id}"/>
-    <c:param name="coverArtSize" value="200"/>
+    <c:param name="coverArtSize" value="160"/>
 </c:import>
 </div>
 

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/podcastChannels.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/podcastChannels.jsp
@@ -42,7 +42,7 @@
     <div class="albumThumb">
         <c:import url="coverArt.jsp">
             <c:param name="podcastChannelId" value="${channel.key.id}"/>
-            <c:param name="coverArtSize" value="200"/>
+            <c:param name="coverArtSize" value="160"/>
             <c:param name="caption1" value="${fn:escapeXml(channel.key.title)}"/>
             <c:param name="caption2" value="${caption2}"/>
             <c:param name="captionCount" value="2"/>


### PR DESCRIPTION
Reduce it to a standard "medium" (160) instead of a custom 200

Difference looks like:

![image](https://user-images.githubusercontent.com/45723468/82062340-cf870700-967e-11ea-8bf6-98f7d7669931.png)

vs

![image](https://user-images.githubusercontent.com/45723468/82063166-fe51ad00-967f-11ea-96f2-c5328ce1428b.png)

--

![image](https://user-images.githubusercontent.com/45723468/82062518-183ec000-967f-11ea-8bdb-975e324cdf18.png)

vs

![image](https://user-images.githubusercontent.com/45723468/82062916-aa46c880-967f-11ea-93df-82ba3e6114bb.png)
