### PR TITLE
Shut down scan pool properly in case of exceptions

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -193,8 +193,8 @@ public class MediaScannerService {
 
         CompletableFuture.runAsync(() -> doScanLibrary(pool), pool)
                 .thenRunAsync(() -> playlistService.importPlaylists(), pool)
-                .thenRun(() -> pool.shutdown())
-                .thenRun(() -> setScanning(false));
+                .whenComplete((r,e) -> pool.shutdown())
+                .whenComplete((r,e) -> setScanning(false));
     }
 
     private void doScanLibrary(ForkJoinPool pool) {


### PR DESCRIPTION
Discovered during discussions in https://github.com/airsonic/airsonic/pull/1662