### PR TITLE
Fix showing album view for podcasts

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/dao/PodcastDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/PodcastDao.java
@@ -157,6 +157,11 @@ public class PodcastDao extends AbstractDao {
         return queryOne(sql, episodeRowMapper, url);
     }
 
+    public PodcastEpisode getEpisodeByPath(String path) {
+        String sql = "select " + EPISODE_QUERY_COLUMNS + " from podcast_episode where path=?";
+        return queryOne(sql, episodeRowMapper, path);
+    }
+
     /**
      * Updates the given Podcast episode.
      *

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -181,6 +181,10 @@ public class MediaFile {
         return mediaType == MediaType.ALBUM;
     }
 
+    public boolean isPodcast() {
+        return mediaType == MediaType.PODCAST;
+    }
+
     public String getTitle() {
         return title;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -181,6 +181,13 @@ public class PodcastService {
     }
 
     /**
+     * Returns a single Podcast channel id by media file.
+     */
+    public int getChannelIdByMediaFile(MediaFile mediaFile) {
+        return podcastDao.getEpisodeByPath(mediaFile.getPath()).getChannelId();
+    }
+
+    /**
      * Returns all Podcast channels.
      *
      * @return Possibly empty list of all Podcast channels.


### PR DESCRIPTION
Bug was reported here by myself: https://github.com/airsonic/airsonic/issues/1554

When clicking on several links of podcasts, you're getting to the album view of podcast, which actually shouldn't exist. You should get the podcast channel view.
This pull requests fixes all these links by forwarding from main.view to the corresponding podcastChannel.view. I found this approach way easier then changing all the links around in Airsonic (now playing/recently played, playlist and player).

Unfortunately there was no real link from the MEDIA_FILE table to the PODCAST_EPISODE table to get the podcast channel. The only link was the PATH column. So I had to use this column to get the corresponding podcast channel of the media file id passed by the url in the MainController.
I think it would be better to have a propper key between MEDIA_FILE and PODCAST_EPISODE, but adding doing that is way beyond my skills. 
