### PR TITLE
Update InternetRadioService to support direct binary urls

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/InternetRadioService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/InternetRadioService.java
@@ -155,10 +155,29 @@ public class InternetRadioService {
      * @return a list of internet radio sources
      */
     private List<InternetRadioSource> retrieveInternetRadioSources(InternetRadio radio, int maxCount, long maxByteSize, int maxRedirects) throws Exception {
-        // Retrieve the remote playlist
-        String playlistUrl = radio.getStreamUrl();
-        LOG.debug("Parsing internet radio playlist at {}...", playlistUrl);
-        SpecificPlaylist inputPlaylist = retrievePlaylist(new URL(playlistUrl), maxByteSize, maxRedirects);
+        String streamUrl = radio.getStreamUrl();
+        LOG.debug("Parsing internet radio (playlist) at {}...", streamUrl);
+
+        SpecificPlaylist inputPlaylist = null;
+        HttpURLConnection urlConnection = connectToURLWithRedirects(new URL(streamUrl), maxRedirects);
+        try (InputStream in = urlConnection.getInputStream()) {
+            String contentType = urlConnection.getContentType();
+            if ("audio/mpeg".equals(contentType)) {
+                //for direct binary streams, just return a collection with a single internet radio source
+                return Collections.singletonList(new InternetRadioSource(streamUrl));
+            }
+            String contentEncoding = urlConnection.getContentEncoding();
+            if (maxByteSize > 0) {
+                inputPlaylist = SpecificPlaylistFactory.getInstance().readFrom(new BoundedInputStream(in, maxByteSize), contentEncoding);
+            } else {
+                inputPlaylist = SpecificPlaylistFactory.getInstance().readFrom(in, contentEncoding);
+            }
+        } finally {
+            urlConnection.disconnect();
+        }
+        if (inputPlaylist == null) {
+            throw new PlaylistFormatUnsupported("Unsupported playlist format " + streamUrl);
+        }
 
         // Retrieve stream URLs
         List<InternetRadioSource> entries = new ArrayList<>();
@@ -218,34 +237,6 @@ public class InternetRadioService {
         }
 
         return entries;
-    }
-
-    /**
-     * Retrieve playlist data from a given URL.
-     *
-     * @param url URL to the remote playlist
-     * @param maxByteSize maximum size of the response, in bytes, or 0 if unlimited
-     * @param maxRedirects maximum number of redirects, or 0 if unlimited
-     * @return the remote playlist data
-     */
-    protected SpecificPlaylist retrievePlaylist(URL url, long maxByteSize, int maxRedirects) throws IOException, PlaylistException {
-
-        SpecificPlaylist playlist;
-        HttpURLConnection urlConnection = connectToURLWithRedirects(url, maxRedirects);
-        try (InputStream in = urlConnection.getInputStream()) {
-            String contentEncoding = urlConnection.getContentEncoding();
-            if (maxByteSize > 0) {
-                playlist = SpecificPlaylistFactory.getInstance().readFrom(new BoundedInputStream(in, maxByteSize), contentEncoding);
-            } else {
-                playlist = SpecificPlaylistFactory.getInstance().readFrom(in, contentEncoding);
-            }
-        } finally {
-            urlConnection.disconnect();
-        }
-        if (playlist == null) {
-            throw new PlaylistFormatUnsupported("Unsupported playlist format " + url.toString());
-        }
-        return playlist;
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/InternetRadioService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/InternetRadioService.java
@@ -130,7 +130,6 @@ public class InternetRadioService {
 
     /**
      * Retrieve a list of sources from the given internet radio
-     * The radio stream can either by binary or a playlist pointing to binary streams
      *
      * This method uses a default maximum limit of PLAYLIST_REMOTE_MAX_LENGTH sources.
      *
@@ -138,24 +137,12 @@ public class InternetRadioService {
      * @return a list of internet radio sources
      */
     private List<InternetRadioSource> retrieveInternetRadioSources(InternetRadio radio) throws Exception {
-        String streamUrl = radio.getStreamUrl();
-        HttpURLConnection urlConnection = connectToURLWithRedirects(new URL(streamUrl), PLAYLIST_REMOTE_MAX_REDIRECTS);
-        String contentType = urlConnection.getContentType();
-        if ("audio/mpeg".equals(contentType)) {
-            //for direct binary streams
-            List<InternetRadioSource> entries = new ArrayList<>();
-            entries.add(new InternetRadioSource(streamUrl));
-            return entries;
-        } else {
-            //for playlists containing binary streams
-            return retrieveInternetRadioSources(
-                    radio,
-                    PLAYLIST_REMOTE_MAX_LENGTH,
-                    PLAYLIST_REMOTE_MAX_BYTE_SIZE,
-                    PLAYLIST_REMOTE_MAX_REDIRECTS
-            );
-        }
-
+        return retrieveInternetRadioSources(
+            radio,
+            PLAYLIST_REMOTE_MAX_LENGTH,
+            PLAYLIST_REMOTE_MAX_BYTE_SIZE,
+            PLAYLIST_REMOTE_MAX_REDIRECTS
+        );
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/service/InternetRadioService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/InternetRadioService.java
@@ -141,7 +141,7 @@ public class InternetRadioService {
         String streamUrl = radio.getStreamUrl();
         HttpURLConnection urlConnection = connectToURLWithRedirects(new URL(streamUrl), PLAYLIST_REMOTE_MAX_REDIRECTS);
         String contentType = urlConnection.getContentType();
-        if (contentType.equals("audio/mpeg")) {
+        if ("audio/mpeg".equals(contentType)) {
             //for direct binary streams
             List<InternetRadioSource> entries = new ArrayList<>();
             entries.add(new InternetRadioSource(streamUrl));


### PR DESCRIPTION
Fixes this issue https://github.com/airsonic/airsonic/issues/1209
In the current release the specified radio url in the settings should point to a m3u-file containing urls to radio streams.
With this update you can now also directly specify the url to a binary radio stream.