### PR TITLE
Rename IgnoreFileTimestamps to FullScan

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The following properties are new in Airsonic-Advanced:
 The following property names are different between Airsonic and Airsonic-Advanced:
   - `UPNP_PORT` -> `UPnpPort`
   - `server.context-path` -> `server.servlet.context-path` (Airsonic will use the latter from 11.0 onwards)
+  - `IgnoreFileTimestamps` -> `FullScan`
 
 Note that Airsonic-Advanced communicates with its Web UI via websockets. If you're behind a proxy, you need to enable websockets and allow UPGRADE http requests through the proxy. A sample configuration is posted here: [nginx sample](https://github.com/airsonic-advanced/airsonic-advanced/issues/145)
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -155,7 +155,7 @@ public class MediaFileService {
 
     private MediaFile checkLastModified(MediaFile mediaFile, boolean useFastCache) {
         if (useFastCache || (mediaFile.getVersion() >= MediaFileDao.VERSION
-                && !settingsService.isIgnoreFileTimestamps()
+                && !settingsService.getFullScan()
                 && mediaFile.getChanged().compareTo(FileUtil.lastModified(mediaFile.getFile())) > -1)) {
             LOG.debug("Detected unmodified file (id {}, path {})", mediaFile.getId(), mediaFile.getPath());
             return mediaFile;

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -87,7 +87,7 @@ public class SettingsService {
     private static final String KEY_INDEX_CREATION_INTERVAL = "IndexCreationInterval";
     private static final String KEY_INDEX_CREATION_HOUR = "IndexCreationHour";
     private static final String KEY_FAST_CACHE_ENABLED = "FastCacheEnabled";
-    private static final String KEY_IGNORE_FILE_TIMESTAMPS = "IgnoreFileTimestamps";
+    private static final String KEY_FULL_SCAN = "FullScan";
     private static final String KEY_PODCAST_UPDATE_INTERVAL = "PodcastUpdateInterval";
     private static final String KEY_PODCAST_FOLDER = "PodcastFolder";
     private static final String KEY_PODCAST_EPISODE_RETENTION_COUNT = "PodcastEpisodeRetentionCount";
@@ -181,7 +181,7 @@ public class SettingsService {
     private static final int DEFAULT_INDEX_CREATION_INTERVAL = 1;
     private static final int DEFAULT_INDEX_CREATION_HOUR = 3;
     private static final boolean DEFAULT_FAST_CACHE_ENABLED = false;
-    private static final boolean DEFAULT_IGNORE_FILE_TIMESTAMPS = false;
+    private static final boolean DEFAULT_FULL_SCAN = false;
     private static final int DEFAULT_PODCAST_UPDATE_INTERVAL = 24;
     private static final String DEFAULT_PODCAST_FOLDER = Util.getDefaultPodcastFolder();
     private static final int DEFAULT_PODCAST_EPISODE_RETENTION_COUNT = 10;
@@ -299,6 +299,7 @@ public class SettingsService {
         keyMaps.put("DatabaseUsertableQuote", KEY_DATABASE_MIGRATION_PARAMETER_USERTABLE_QUOTE);
 
         keyMaps.put("airsonic.rememberMeKey", KEY_REMEMBER_ME_KEY);
+        keyMaps.put("IgnoreFileTimestamps", KEY_FULL_SCAN);
 
         return keyMaps;
     }
@@ -663,12 +664,12 @@ public class SettingsService {
         setBoolean(KEY_FAST_CACHE_ENABLED, enabled);
     }
 
-    public boolean isIgnoreFileTimestamps() {
-        return getBoolean(KEY_IGNORE_FILE_TIMESTAMPS, DEFAULT_IGNORE_FILE_TIMESTAMPS);
+    public boolean getFullScan() {
+        return getBoolean(KEY_FULL_SCAN, DEFAULT_FULL_SCAN);
     }
 
-    public void setIgnoreFileTimestamps(boolean ignore) {
-        setBoolean(KEY_IGNORE_FILE_TIMESTAMPS, ignore);
+    public void setFullScan(boolean fullscan) {
+        setBoolean(KEY_FULL_SCAN, fullscan);
     }
 
     /**


### PR DESCRIPTION
Because IgnoreFileTimeStamps is useful at a technical level but does not describe the high level reason of the property