### PR TITLE
Fix player id autoincrement issue

### DIFF
--- a/airsonic-main/src/main/resources/liquibase/11.0/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.0/changelog.xml
@@ -11,4 +11,5 @@
     <include file="user-roles-json.xml" relativeToChangelogFile="true"/>
     <include file="remove-password-column.xml" relativeToChangelogFile="true"/>
     <include file="add-sonos-table-link.xml" relativeToChangelogFile="true"/>
+    <include file="player-id-autoincrement.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/11.0/player-id-autoincrement.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.0/player-id-autoincrement.xml
@@ -1,0 +1,14 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="player-id-autoincrement" author="anon">
+        <addAutoIncrement columnDataType="int"
+		  columnName="id"
+		  incrementBy="1"  
+		  schemaName="public" 
+		  tableName="player"/>
+        <rollback>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/11.0/player-id-autoincrement.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.0/player-id-autoincrement.xml
@@ -3,11 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="player-id-autoincrement" author="anon">
-        <addAutoIncrement columnDataType="int"
-		  columnName="id"
-		  incrementBy="1"  
-		  schemaName="public" 
-		  tableName="player"/>
+        <addAutoIncrement columnDataType="int" columnName="id" tableName="player"/>
         <rollback>
         </rollback>
     </changeSet>


### PR DESCRIPTION
New players cannot be created because the code now relies on autoincrement feature for ids in player table but that schema modification wasn't done yet.