### PR TITLE
Add armhf Dockerfile.

### DIFF
--- a/install/docker/Dockerfile.armhf
+++ b/install/docker/Dockerfile.armhf
@@ -1,0 +1,44 @@
+FROM arm32v7/adoptopenjdk:14-jre-hotspot
+
+LABEL description="Airsonic-Advanced is a free, web-based media streamer, providing ubiquitous access to your music." \
+      url="https://github.com/airsonic-advanced/airsonic-advanced"
+
+ENV AIRSONIC_PORT=4040 AIRSONIC_DIR=/var CONTEXT_PATH=/ UPNP_PORT=4041 PUID=0 PGID=0
+
+WORKDIR $AIRSONIC_DIR
+
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-armhf /usr/local/bin/tini
+RUN chmod +x /usr/local/bin/tini
+
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository -y ppa:jonathonf/ffmpeg-4 && \
+    apt-get update && \
+    apt-get install -y ffmpeg \
+                       x264 \
+                       x265 \
+                       lame \
+                       bash \
+                       ttf-dejavu \
+                       gosu
+
+COPY run.sh /usr/local/bin/run.sh
+RUN chmod +x /usr/local/bin/run.sh
+COPY entry.sh /usr/local/bin/entry.sh
+RUN chmod +x /usr/local/bin/entry.sh
+
+COPY target/dependency/airsonic-main.war airsonic.war
+
+EXPOSE $AIRSONIC_PORT
+
+# Default DLNA/UPnP ports
+EXPOSE $UPNP_PORT
+EXPOSE 1900/udp
+
+USER ${PUID}:${PGID}
+
+VOLUME $AIRSONIC_DIR/airsonic $AIRSONIC_DIR/music $AIRSONIC_DIR/playlists $AIRSONIC_DIR/podcasts
+
+HEALTHCHECK --interval=15s --timeout=3s CMD curl -f http://localhost:"$AIRSONIC_PORT""$CONTEXT_PATH"rest/ping || false
+
+ENTRYPOINT ["tini", "--", "entry.sh"]


### PR DESCRIPTION
This adds an armhf equivalent of the Dockerfile, addressing https://github.com/airsonic-advanced/airsonic-advanced/issues/359 (though you'd likely need something similar for 64 bit). This lets you run airsonic-advanced on devices like Raspberry Pi.

The only differences are the adoptopenjdk and the tini binary to use.

The docker manifest would need to be updated to publish both architectures (eg. https://dev.to/toolboc/publish-multi-arch-docker-images-to-a-single-repo-with-docker-manifests-329n)