### PR TITLE
Put radio station names in title attribute

### DIFF
--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/left.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/left.jsp
@@ -173,10 +173,10 @@
             <span style="vertical-align: middle">
                 <c:choose>
                     <c:when test="${empty radio.homepageUrl}">
-                        ${fn:escapeXml(radio.name)}
+                        <span title="${fn:escapeXml(radio.name)}">${fn:escapeXml(radio.name)}</span>
                     </c:when>
                     <c:otherwise>
-                        <a target="_blank" rel="noopener" href="${radio.homepageUrl}">${fn:escapeXml(radio.name)}</a>
+                        <a target="_blank" rel="noopener" href="${radio.homepageUrl}" title="Visit ${fn:escapeXml(radio.name)}">${fn:escapeXml(radio.name)}</a>
                     </c:otherwise>
                 </c:choose>
             </span>


### PR DESCRIPTION
This should allow seeing the radio station name if it doesn't fully fit in the view.

This is *not* tested, as I do not have an environment to test in, however it's fairly simple and should have no problems as long as quotes are being escaped somewhere (they generally aren't be in URLs anyways)

Contributing
  1.  **License Acceptance** All contributions must be licensed as [GNU GPLv3](https://github.com/airsonic/airsonic/blob/develop/LICENSE.txt) to be accepted. Use [`git commit --signoff`](https://jk.gs/git-commit.html) to acknowledge this.

I'm in the browser, and I'm pretty sure this is trivial enough to not need it? I can (eventually) clone locally if necessary, but my current environment is broken due to a partially restored backup.