### PR TITLE
Add transcode estimate paddings as a global setting

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/TranscodingSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/TranscodingSettingsController.java
@@ -59,6 +59,8 @@ public class TranscodingSettingsController {
         map.put("transcodeDirectory", transcodingService.getTranscodeDirectory());
         map.put("downsampleCommand", settingsService.getDownsamplingCommand());
         map.put("hlsCommand", settingsService.getHlsCommand());
+        map.put("transcodeEstimateTimePadding", settingsService.getTranscodeEstimateTimePadding());
+        map.put("transcodeEstimateBytePadding", settingsService.getTranscodeEstimateBytePadding());
         map.put("brand", settingsService.getBrand());
 
         model.addAttribute("model", map);
@@ -135,6 +137,12 @@ public class TranscodingSettingsController {
         }
         settingsService.setDownsamplingCommand(StringUtils.trim(request.getParameter("downsampleCommand")));
         settingsService.setHlsCommand(StringUtils.trim(request.getParameter("hlsCommand")));
+
+        String timePad = StringUtils.trimToNull(request.getParameter("transcodeEstimateTimePadding"));
+        String bytePad = StringUtils.trimToNull(request.getParameter("transcodeEstimateBytePadding"));
+        settingsService.setTranscodeEstimateTimePadding(timePad == null ? null : Long.parseLong(timePad));
+        settingsService.setTranscodeEstimateBytePadding(bytePad == null ? null : Long.parseLong(bytePad));
+
         settingsService.save();
         return null;
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -90,6 +90,8 @@ public class SettingsService {
     private static final String KEY_FAST_CACHE_ENABLED = "FastCacheEnabled";
     private static final String KEY_FULL_SCAN = "FullScan";
     private static final String KEY_CLEAR_FULL_SCAN_SETTING_AFTER_SCAN = "ClearFullScanSettingAfterScan";
+    private static final String KEY_TRANSCODE_ESTIMATE_TIME_PADDING = "TranscodeEstimateTimePadding";
+    private static final String KEY_TRANSCODE_ESTIMATE_BYTE_PADDING = "TranscodeEstimateBytePadding";
     private static final String KEY_PODCAST_UPDATE_INTERVAL = "PodcastUpdateInterval";
     private static final String KEY_PODCAST_FOLDER = "PodcastFolder";
     private static final String KEY_PODCAST_EPISODE_RETENTION_COUNT = "PodcastEpisodeRetentionCount";
@@ -186,6 +188,8 @@ public class SettingsService {
     private static final boolean DEFAULT_FAST_CACHE_ENABLED = false;
     private static final boolean DEFAULT_FULL_SCAN = false;
     private static final boolean DEFAULT_CLEAR_FULL_SCAN_SETTING_AFTER_SCAN = false;
+    private static final long DEFAULT_TRANSCODE_ESTIMATE_TIME_PADDING = 2000;
+    private static final long DEFAULT_TRANSCODE_ESTIMATE_BYTE_PADDING = 0;
     private static final int DEFAULT_PODCAST_UPDATE_INTERVAL = 24;
     private static final String DEFAULT_PODCAST_FOLDER = Util.getDefaultPodcastFolder();
     private static final int DEFAULT_PODCAST_EPISODE_RETENTION_COUNT = 10;
@@ -696,6 +700,22 @@ public class SettingsService {
     public void setClearFullScanSettingAfterScan(Boolean clear) {
         setBoolean(KEY_CLEAR_FULL_SCAN_SETTING_AFTER_SCAN, clear);
     }
+
+    public long getTranscodeEstimateTimePadding() {
+        return getLong(KEY_TRANSCODE_ESTIMATE_TIME_PADDING, DEFAULT_TRANSCODE_ESTIMATE_TIME_PADDING);
+    };
+
+    public void setTranscodeEstimateTimePadding(Long timeInMillis) {
+        setLong(KEY_TRANSCODE_ESTIMATE_TIME_PADDING, timeInMillis);
+    };
+
+    public long getTranscodeEstimateBytePadding() {
+        return getLong(KEY_TRANSCODE_ESTIMATE_BYTE_PADDING, DEFAULT_TRANSCODE_ESTIMATE_BYTE_PADDING);
+    };
+
+    public void setTranscodeEstimateBytePadding(Long bytes) {
+        setLong(KEY_TRANSCODE_ESTIMATE_BYTE_PADDING, bytes);
+    };
 
     /**
      * Returns the number of hours between Podcast updates, of -1 if automatic updates

--- a/airsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
@@ -513,8 +513,9 @@ public class TranscodingService {
             return null;
         }
 
-        // Over-estimate size a bit (2 seconds) so don't cut off early in case of small calculation differences
-        return Math.round((duration + 2) * maxBitRate * 1000L / 8L);
+        // Over-estimate size a bit (a custom time surplus plus a custom byte surplus) so don't cut off early in case of small calculation differences
+        return Math.round((duration + (settingsService.getTranscodeEstimateTimePadding() / 1000.0)) * maxBitRate * 1000L / 8L)
+                + settingsService.getTranscodeEstimateBytePadding();
     }
 
     private boolean isRangeAllowed(Parameters parameters) {

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
@@ -326,6 +326,8 @@ generalsettings.theme=Default theme
 
 advancedsettings.downsamplecommand=Downsample command
 advancedsettings.hlscommand=HTTP Live Streaming command
+advancedsettings.transcodeestimatetimepadding=Transcode Estimate Time Padding (ms)
+advancedsettings.transcodeestimatebytepadding=Transcode Estimate Byte Padding (bytes)
 advancedsettings.downloadlimit=Download limit (Kbps)<br><div class="detail">(0 = Unlimited)</div>
 advancedsettings.uploadlimit=Upload limit (Kbps)<br><div class="detail">(0 = Unlimited)</div>
 advancedsettings.streamport=Non-SSL stream port<br><div class="detail">(0 = Disabled)</div>
@@ -832,3 +834,7 @@ helppopup.credentialsjwtkey.title=JWT Key
 helppopup.credentialsjwtkey.text=Signs and verifies all JWT tokens used when sharing music. Changing your JWT key will render all old Shares inaccessible.
 helppopup.credentialsadd.title=Add Credentials
 helppopup.credentialsadd.text=Only ADDs NEW credentials. Does NOT REMOVE OLD credentials. Removal of OLD credentials must be done explicitly in the <a href="credentialSettings.view">Credentials Settings</a> tab
+helppopup.transcodeestimatetimepadding.title=Transcode Estimate Time Padding
+helppopup.transcodeestimatetimepadding.text=When transcoding, the server needs to send the final file size of the transcoded file to the client at the beginning even though the transcoding hasn\'t completed. An estimate is sent instead and is calculated by multiplying the specified average bitrate of the transcode and the duration of the source file. To guard against the case that the final transcode size exceeds this estimated size (in case the final bitrate exceeds the target average bitrate), a time padding is added to the source duration when calculating the final size. If the final transcode ends up being exactly the estimated size (a highly unlikely but best-case scenario), the stream is terminated without any issues. If the transcode is smaller than the estimate (a more likely but still preferable scenario), the server fills and sends the remaining stream with junk data until the size is satisfied. In case the final transcode exceeds the estimated size budget (a non-desirable scenario), the transcoder throws an exception and terminates immediately (since the browser won't accept any more bytes than it was originally told).
+helppopup.transcodeestimatebytepadding.title=Transcode Estimate Byte Padding
+helppopup.transcodeestimatebytepadding.text=Instead of adding a time pad for transcoding (as explained in the Transcode Estimate Time Padding), a flat number of bytes may also be added as a pad to guard against underestimating the final transcode size. Time padding is multiplied by the transcoded stream's bitrate and so the estimate changes as the bitrate changes. The byte padding is a constant padding regardless of the bitrate of the final transcoded stream.

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/transcodingSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/transcodingSettings.jsp
@@ -79,6 +79,26 @@
         </tr>
     </table>
 
+    <table style="white-space:nowrap" class="indent">
+        <tr>
+            <td style="font-weight: bold;">
+                <fmt:message key="advancedsettings.transcodeestimatetimepadding"/>
+                <c:import url="helpToolTip.jsp"><c:param name="topic" value="transcodeestimatetimepadding"/></c:import>
+            </td>
+            <td>
+                <input class="monospace" name="transcodeEstimateTimePadding" size="8" value="${model.transcodeEstimateTimePadding}"/>
+            </td>
+        </tr>
+        <tr>
+            <td style="font-weight: bold;">
+                <fmt:message key="advancedsettings.transcodeestimatebytepadding"/>
+                <c:import url="helpToolTip.jsp"><c:param name="topic" value="transcodeestimatebytepadding"/></c:import>
+            </td>
+            <td>
+                <input class="monospace" name="transcodeEstimateBytePadding" size="8" value="${model.transcodeEstimateBytePadding}"/>
+            </td>
+        </tr>
+    </table>
 
     <p style="padding-top:0.75em">
         <input type="submit" value="<fmt:message key='common.save'/>" style="margin-right:0.3em">


### PR DESCRIPTION
Transcoding converts a source file to a transcoded file using a specified target bitrate.

When transcoding on the fly, the final size of the transcoded file is unknown until the transcoding finishes.
However, for the sake of seeking and other things, browsers and other clients require the final size of the transcoded file to be sent upfront at the beginning.

Airsonic server estimates the final size of the transcoded file and sends it to the client at the start of the transcode.
The estimated size used to be calculated as:
Transcoded Size = Target Bitrate x (Source duration + 2s) 

The extra 2s are added as a safety guard in case the estimate turns out to be an underestimate and the final size turns out to be bigger. This is likely because bitrates are average estimates. In this scenario, as soon as the transcoder reaches the target number of bytes prematurely (because the size was underestimated), it throws an exception and terminates since the client won't accept any additional bytes, which is a scenario posed in https://github.com/airsonic-advanced/airsonic-advanced/issues/390#issuecomment-703637803.
On the other hand, if the estimate turns out to be an overestimate (a more desireable scenario), the rest of the stream is filled and sent with junk data until the number of byte estimated is satisfied. 

However, it turns out with some transcode profiles, 2s isn't enough of a buffer window. Thus, the necessity of this PR.

This PR makes it so that the estimate is now calculated as follows:
Transcoded Size = Target Bitrate x (Source duration + Custom Time Padding) + Custom Byte Padding

Both the Time Padding and the Byte Padding are customizable in the Transcode Settings GUI. The Time Padding adds a variable number of bytes to the estimated size depending on the bitrate, whereas the Byte Padding adds a fixed constant.
The default values are:
Time padding is 2s as before
Byte padding is 0 bytes as before

For people experiencing issues as in https://github.com/airsonic-advanced/airsonic-advanced/issues/390#issuecomment-703637803 , they may increase either padding and it should help get a bigger estimate and thus a bigger byte budget.

Note that this is a global setting and so applies to all songs and transcodes.

Fixes #390 