### PR TITLE
rest api: add support for basic auth

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/security/GlobalSecurityConfig.java
@@ -34,6 +34,7 @@ import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
 import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
@@ -282,7 +283,9 @@ public class GlobalSecurityConfig {
             http
                     .cors()
                     .and()
-                    .addFilterBefore(restAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                    .httpBasic()
+                    .and()
+                    .addFilterAfter(restAuthenticationFilter, BasicAuthenticationFilter.class)
                     .csrf()
                     .ignoringAntMatchers("/ws/Sonos/**")
                     .requireCsrfProtectionMatcher(csrfSecurityRequestMatcher)

--- a/airsonic-main/src/test/java/org/airsonic/player/security/RESTAuthTest.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/security/RESTAuthTest.java
@@ -1,0 +1,97 @@
+package org.airsonic.player.security;
+
+import org.airsonic.player.util.HomeRule;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class RESTAuthTest {
+
+    private static final String USERNAME = "admin";
+    private static final String PASSWORD = "admin";
+    private static final String API_VERSION = "1.15.0";
+
+    @ClassRule
+    public static final HomeRule homeRule = new HomeRule();
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mvc;
+
+    @Before
+    public void setup() {
+        mvc = MockMvcBuilders
+                .webAppContextSetup(wac)
+                .apply(springSecurity())
+                .dispatchOptions(true)
+                .alwaysDo(print())
+                .build();
+    }
+
+    @Test
+    public void testRequestParamAuthSuccess() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("f", "json")
+                .param("c", "test")
+                .param("u", USERNAME)
+                .param("p", PASSWORD)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"));
+    }
+
+    @Test
+    public void testRequestParamAuthFailure() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .param("u", USERNAME)
+                .param("p", "incorrectpassword"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.error.code").value(40));
+    }
+
+    @Test
+    public void testBasicAuthSuccess() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .with(httpBasic(USERNAME, PASSWORD))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subsonic-response.status").value("ok"));
+    }
+
+    @Test
+    public void testBasicAuthFailure() throws Exception {
+        mvc.perform(get("/rest/getArtists")
+                .param("v", API_VERSION)
+                .param("c", "test")
+                .param("f", "json")
+                .with(httpBasic(USERNAME, "incorrectpassword"))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+}


### PR DESCRIPTION
Adds support for using HTTP basic authentication with REST API instead of passing credentials in query string.