### PR TITLE
Fix CORs Origin pattern again

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/spring/WebsocketConfiguration.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/spring/WebsocketConfiguration.java
@@ -44,7 +44,7 @@ public class WebsocketConfiguration implements WebSocketMessageBrokerConfigurer 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/websocket")
-                // .setAllowedOrigins("*")
+                .setAllowedOriginPatterns("*")
                 .addInterceptors(new ServletRequestCaptureHandshakeInterceptor())
                 .withSockJS()
                 .setClientLibraryUrl("../../script/sockjs-1.5.0.min.js");


### PR DESCRIPTION
Continuation of the issue in https://github.com/airsonic-advanced/airsonic-advanced/pull/433
Hopefully prevents people needing to add empty Origin headers in proxies like in https://github.com/airsonic-advanced/airsonic-advanced/issues/462