### PR TITLE
Add mod transcoding to mp3 and install xmp in docker container to decode mod files

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -162,7 +162,7 @@ public class SettingsService {
     private static final String DEFAULT_IGNORED_ARTICLES = "The El La Los Las Le Les";
     private static final String DEFAULT_SHORTCUTS = "New Incoming Podcast";
     private static final String DEFAULT_PLAYLIST_FOLDER = Util.getDefaultPlaylistFolder();
-    private static final String DEFAULT_MUSIC_FILE_TYPES = "mp3 ogg oga aac m4a m4b flac wav wma aif aiff ape mpc shn mka opus";
+    private static final String DEFAULT_MUSIC_FILE_TYPES = "mp3 ogg oga aac m4a m4b flac wav wma aif aiff ape mpc shn mka opus alm 669 mdl far xm mod fnk imf it liq wow mtm ptm rtm stm s3m ult dmf dbm med okt emod sfx m15 mtn amf gdm stx gmc psm j2b umx amd rad hsc flx gtk mgt mtp";
     private static final String DEFAULT_VIDEO_FILE_TYPES = "flv avi mpg mpeg mp4 m4v mkv mov wmv ogv divx m2ts webm";
     private static final String DEFAULT_COVER_ART_FILE_TYPES = "cover.jpg cover.png cover.gif folder.jpg jpg jpeg gif png";
     private static final String DEFAULT_COVER_ART_SOURCE = CoverArtSource.FILETAG.name();

--- a/airsonic-main/src/main/resources/liquibase/11.0/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.0/changelog.xml
@@ -12,4 +12,5 @@
     <include file="remove-password-column.xml" relativeToChangelogFile="true"/>
     <include file="add-sonos-table-link.xml" relativeToChangelogFile="true"/>
     <include file="podcast-description-text.xml" relativeToChangelogFile="true"/>
+    <include file="insert-mod-transcoding.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/11.0/insert-mod-transcoding.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.0/insert-mod-transcoding.xml
@@ -1,0 +1,20 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="insert-mod-transcoding" author="anon">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="transcoding"/>
+        </preConditions>
+        <insert tableName="transcoding">
+            <column name="name" value="mod > mp3" />
+            <column name="source_formats" value="alm 669 mdl far xm mod fnk imf it liq wow mtm ptm rtm stm s3m ult dmf dbm med okt emod sfx m15 mtn amf gdm stx gmc psm j2b umx amd rad hsc flx gtk mgt mtp" />
+            <column name="target_format" value="mp3" />
+            <column name="step1" value="xmp -Dlittle-endian -q -c %s"/>
+            <column name="step2" value="lame -r -b %b -S --resample 44.1 - -"/>
+        </insert>
+        <rollback>
+            <delete tableName="transcoding"><where>name = 'mod > mp3'</where></delete>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
                        x264 \
                        x265 \
                        lame \
+                       xmp \
                        bash \
                        ttf-dejavu \
                        gosu


### PR DESCRIPTION
Will need to register the following extensions as Music types in Settings -> General also

alm 669 mdl far xm mod fnk imf it liq wow mtm ptm rtm stm s3m ult dmf dbm med okt emod sfx m15 mtn amf gdm stx gmc psm j2b umx amd rad hsc flx gtk mgt mtp

Default adds these already, but won't override if a custom list already exists in the parameter file, so do add them.

Note, needs xmp. In Docker container, xmp is installed.

Fixes https://github.com/airsonic/airsonic/issues/1698