### PR TITLE
Order Albums by a secondary index other than create_date as create_dates are not unique

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/dao/AlbumDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/AlbumDao.java
@@ -254,7 +254,7 @@ public class AlbumDao extends AbstractDao {
         args.put("count", count);
         args.put("offset", offset);
         return namedQuery("select " + QUERY_COLUMNS + " from album where present and folder_id in (:folders) " +
-                          "order by created desc limit :count offset :offset", rowMapper, args);
+                "order by created desc, id desc limit :count offset :offset", rowMapper, args);
     }
 
     /**


### PR DESCRIPTION
Fixes #483