### PR TITLE
FFMPEG Metadata parse for all files

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/TagWSController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/TagWSController.java
@@ -69,7 +69,7 @@ public class TagWSController {
             return "UPDATED";
 
         } catch (Exception x) {
-            LOG.warn("Failed to update tags for " + data.getMediaFileId(), x);
+            LOG.warn("Failed to update tags for {}", data.getMediaFileId(), x);
             return x.getMessage();
         }
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -121,7 +121,7 @@ public class JaudiotaggerParser extends MetaDataParser {
 
 
         } catch (Throwable x) {
-            LOG.warn("Error when parsing tags in " + file, x);
+            LOG.warn("Error when parsing tags in {}", file, x);
         }
 
         return metaData;
@@ -232,7 +232,7 @@ public class JaudiotaggerParser extends MetaDataParser {
             audioFile.commit();
 
         } catch (Throwable x) {
-            LOG.warn("Failed to update tags for file " + file, x);
+            LOG.warn("Failed to update tags for file {}", file, x);
             throw new RuntimeException("Failed to update tags for file " + file + ". " + x.getMessage(), x);
         }
     }
@@ -275,7 +275,7 @@ public class JaudiotaggerParser extends MetaDataParser {
         try {
             return getArtwork(file) != null;
         } catch (Throwable x) {
-            LOG.info("Failed to find cover art tag in " + file, x);
+            LOG.info("Failed to find cover art tag in {}", file, x);
             return false;
         }
     }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataFactoryTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataFactoryTestCase.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -55,7 +55,7 @@ public class MetaDataFactoryTestCase {
         assertThat(parser, instanceOf(FFmpegParser.class));
 
         parser = metaDataParserFactory.getParser(someJunk);
-        assertThat(parser, instanceOf(DefaultMetaDataParser.class));
+        assertThat(parser, instanceOf(FFmpegParser.class));
     }
 
 }

--- a/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataParserTestCase.java
+++ b/airsonic-main/src/test/java/org/airsonic/player/service/metadata/MetaDataParserTestCase.java
@@ -19,29 +19,35 @@
  */
 package org.airsonic.player.service.metadata;
 
-import junit.framework.TestCase;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.service.SettingsService;
+import org.junit.Test;
 
 import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Unit test of {@link MetaDataParser}.
  *
  * @author Sindre Mehus
  */
-public class MetaDataParserTestCase extends TestCase {
+public class MetaDataParserTestCase {
 
+    @Test
     public void testRemoveTrackNumberFromTitle() {
 
         MetaDataParser parser = new MetaDataParser() {
+            @Override
             public MetaData getRawMetaData(Path file) {
                 return null;
             }
 
+            @Override
             public void setMetaData(MediaFile file, MetaData metaData) {
             }
 
+            @Override
             public boolean isEditingSupported() {
                 return false;
             }
@@ -51,6 +57,7 @@ public class MetaDataParserTestCase extends TestCase {
                 return null;
             }
 
+            @Override
             public boolean isApplicable(Path path) {
                 return false;
             }


### PR DESCRIPTION
Previously only parsed video files.

Now logic is:
- jaudiotagger: certain extensions
- ffmpeg: all
- default file-based: all

Will eventually rework to gather info from all tag parsers and combine them