### PR TITLE
Update dependencies (including Lucene)

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.12.0</version>
+            <version>3.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.ldap</groupId>
@@ -269,7 +269,7 @@
         <dependency>
             <groupId>org.jfree</groupId>
             <artifactId>jfreechart</artifactId>
-            <version>1.5.0</version>
+            <version>1.5.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>junit</groupId>
@@ -378,7 +378,7 @@
         <dependency>
             <groupId>de.triology.recaptchav2-java</groupId>
             <artifactId>recaptchav2-java</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.4</version>
         </dependency>
 
         <!-- SONOS API / WSDL SUPPORT -->
@@ -433,7 +433,7 @@
         <dependency>
             <groupId>com.mattbertolini</groupId>
             <artifactId>liquibase-slf4j</artifactId>
-            <version>2.0.0</version>
+            <version>4.0.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -164,12 +164,12 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>8.4.1</version>
+            <version>8.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
-            <version>8.4.1</version>
+            <version>8.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>

--- a/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
@@ -73,7 +73,7 @@ public class IndexManager {
      *    DocumentFactory or the class that they use.
      *
      */
-    private static final int INDEX_VERSION = 18;
+    private static final int INDEX_VERSION = 19;
 
     /**
      * Literal name of index top directory.


### PR DESCRIPTION
Upgrading Lucene means a new index, which means a rescan needs to occur before the library stats are generated