### PR TITLE
Strip terminating and embedded \0 in JaudioTaggerParser

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -131,9 +131,17 @@ public class JaudiotaggerParser extends MetaDataParser {
 
     private static String getTagField(Tag tag, FieldKey fieldKey) {
         try {
-            return StringUtils.trimToNull(tag.getFirst(fieldKey));
+            return stripNullCharacters(StringUtils.trimToNull(tag.getFirst(fieldKey)));
         } catch (Exception x) {
             // Ignored.
+            return null;
+        }
+    }
+
+    private String stripNullCharacters(String s) {
+        if (s != null) {
+            return s.replace("\0", "");
+        } else {
             return null;
         }
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -131,17 +131,9 @@ public class JaudiotaggerParser extends MetaDataParser {
 
     private static String getTagField(Tag tag, FieldKey fieldKey) {
         try {
-            return stripNullCharacters(StringUtils.trimToNull(tag.getFirst(fieldKey)));
+            return StringUtils.replace(StringUtils.trimToNull(tag.getFirst(fieldKey)), "\0", " ");
         } catch (Exception x) {
             // Ignored.
-            return null;
-        }
-    }
-
-    private String stripNullCharacters(String s) {
-        if (s != null) {
-            return s.replace("\0", "");
-        } else {
             return null;
         }
     }


### PR DESCRIPTION
Jaudiotagger sometimes returns strings with trailing and (rarely) embedded \0 characters, strip these before storing them in the database. This avoids problems with Postgresql (which can not store \0 in string data types) and it is more correct as these \0 characters should not be there in the first place. Strangely enough Jaudiotagger *does* strip terminating \0 characters when storing WAV info tags in ID3 fields, this patch extends this functionality to all other (string) types and also takes care of embedded stray \0's.

This patch is needed to make airsonic (any version) work reliably with Postgresql. It is a continuation of a similar PR (https://github.com/airsonic/airsonic/pull/1236) to the original airsonic which never got merged.