### PR TITLE
Switch 4thline repository to HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
          -->
         <repository>
             <id>4thline-repo</id>
-            <url>http://4thline.org/m2</url>
+            <url>https://4thline.org/m2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
[Maven 3.8.1](https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291) will actively block http repositories. Therefore building will fail with following message:
```
[INFO] Airsonic ........................................... SUCCESS [  0.244 s]
[INFO] Subsonic REST API .................................. SUCCESS [  1.636 s]
[INFO] Sonos API .......................................... SUCCESS [  2.052 s]
[INFO] Airsonic Main ...................................... FAILURE [  0.231 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.318 s
[INFO] Finished at: 2021-10-10T17:52:14+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project airsonic-main: 
Could not resolve dependencies for project org.airsonic.player:airsonic-main:war:11.0.0-SNAPSHOT: 
Failed to collect dependencies at org.fourthline.cling:cling-core:jar:2.0.1: 
Failed to read artifact descriptor for org.fourthline.cling:cling-core:jar:2.0.1: 
Could not transfer artifact org.fourthline.cling:cling-core:pom:2.0.1 from/to maven-default-http-blocker (http://0.0.0.0/): 
Blocked mirror for repositories: [4thline-repo (http://4thline.org/m2, default, releases)] -> [Help 1]
```

This PR changes the repositories url to https.