### PR TITLE
fix: ignore unused declared dependency on org.springframework:spring-aspects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,7 @@
                                 <ignoredUnusedDeclaredDependency>jakarta.xml.bind:jakarta.xml.bind-api*</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.cxf:cxf-rt-frontend-jaxws</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>jakarta.annotation:jakarta.annotation-api</ignoredUnusedDeclaredDependency>
+				<ignoredUnusedDeclaredDependency>org.springframework:spring-aspects</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This supresses the following error which prevents building:

```
[WARNING] Unused declared dependencies found:
[WARNING]    org.springframework:spring-aspects:jar:5.3.8:compile
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Airsonic 11.0.0-SNAPSHOT:
[INFO] 
[INFO] Airsonic ........................................... SUCCESS [  0.625 s]
[INFO] Subsonic REST API .................................. SUCCESS [  2.672 s]
[INFO] Sonos API .......................................... SUCCESS [  3.297 s]
[INFO] Airsonic Main ...................................... FAILURE [ 27.158 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33.920 s
[INFO] Finished at: 2021-11-28T18:39:55+11:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.1.2:analyze-only (analyze) on project airsonic-main: Dependency problems found -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.1.2:analyze-only (analyze) on project airsonic-main: Dependency problems found
```

I'm not familiar with Maven, but I wonder if there is a way to turn off such checks? It doesn't sound the kind of error that should prevent building/installing.