### PR TITLE
Jaudiotagger does not support APE

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -190,7 +190,7 @@ public class JaudiotaggerParser extends MetaDataParser {
         return settingsService;
     }
 
-    private static Set<String> applicableFormats = ImmutableSet.of("mp3", "m4a", "m4b", "m4p", "aac", "ogg", "flac", "wav", "mpc", "mp+", "ape", "aif", "dsf", "aiff", "wma");
+    private static Set<String> applicableFormats = ImmutableSet.of("mp3", "m4a", "m4b", "m4p", "aac", "ogg", "flac", "wav", "mpc", "mp+", "aif", "dsf", "aiff", "wma");
 
     /**
      * Returns whether this parser is applicable to the given file.


### PR DESCRIPTION
Jaudiotagger does not support APE but JaudiotaggerParser insists it does. There have been several attempts to get this fix implemented in the original Airsonic but somehow it never stuck. Jaudiotagger _DOES NOT SUPPORT APE_ (where is the BLINK tag when you need it?), using it anyway causes APE files to be registered with a duration of 0 which makes them unplayable. By removing APE from the list of supported formats the scanner uses FFmpegParser.java for the format which does work.