### PR TITLE
Replace MoreFiles.getFileExtension() with FilenameUtils.getExtension()

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -19,7 +19,6 @@
  */
 package org.airsonic.player.service;
 
-import com.google.common.io.MoreFiles;
 import org.airsonic.player.ajax.MediaFileEntry;
 import org.airsonic.player.dao.AlbumDao;
 import org.airsonic.player.dao.MediaFileDao;
@@ -414,7 +413,7 @@ public class MediaFileService {
     }
 
     public boolean includeMediaFile(Path candidate) {
-        String suffix = MoreFiles.getFileExtension(candidate).toLowerCase();
+        String suffix = FilenameUtils.getExtension(candidate.toString()).toLowerCase();
         return (!isExcluded(candidate) && (Files.isDirectory(candidate) || isAudioFile(suffix) || isVideoFile(suffix)));
     }
 


### PR DESCRIPTION
This seems to be some ancient remnant of times long gone. Replace `MoreFiles.getFileExtension()` with `FilenameUtils.getExtension()` and drop the now unused import of `com.google.common.io.MoreFiles`

