### PR TITLE
Use database-specific random function

### DIFF
--- a/airsonic-main/src/main/resources/liquibase/11.0/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.0/changelog.xml
@@ -18,4 +18,5 @@
     <include file="podcast-channel-rules.xml" relativeToChangelogFile="true"/>
     <include file="avatar-storage.xml" relativeToChangelogFile="true"/>
     <include file="move-user-table.xml" relativeToChangelogFile="true"/>
+    <include file="postgresql-add-rand-function.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/11.0/postgresql-add-rand-function.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.0/postgresql-add-rand-function.xml
@@ -1,0 +1,15 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="postgresql-add-rand-function" author="yetangitu" dbms="postgresql">
+        <sql>
+            create or replace function rand () returns double precision language sql as $$ select random() $$;
+        </sql>
+        <rollback>
+            drop function rand ();
+        </rollback>
+    </changeSet>
+</databaseChangeLog>
+
+


### PR DESCRIPTION
Fix for #698, "Shuffle radio fails on PostgreSQL"; use a database-specific random function.

PostgreSQL uses `random()`, Mysql/MariaDB and HSQLDB use `rand()`, use `MetaData.getDatabaseProductName()` to check which DBMS is used and adjust the function name accordingly. This clause will still fail on e.g. SQL Server, Oracle and DB2 since these use totally different constructions [1] to select random rows. If these DBMS are to be supported the query needs to be restructured.


 [1]
 - SQL Server uses `SELECT TOP 1 column FROM table ORDER BY NEWID ();`
 - Oracle uses `SELECT column FROM (SELECT column FROM table ORDER BY dbms_random.value) WHERE rownum = 1;`
 - DB2 uses `SELECT column RAND () as IDX  FROM table ORDER BY  IDX FETCH FIRST 1 ROWS ONLY;`
