### PR TITLE
Fix for #712, remove user-visible "User table quote" option from Settings->Database

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -61,7 +61,6 @@ jobs:
               spring_datasource_url: 'jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified&raiseExceptionOnSilentRollback=false'
               spring_datasource_username: postgres
               spring_datasource_password: pass
-              spring_liquibase_parameters_userTableQuote: '"'
               EXCLUDED_TEST_GROUPS: org.airsonic.player.util.EmbeddedTestCategory
           - jdk: 11
             services:
@@ -75,7 +74,6 @@ jobs:
               spring_datasource_url: 'jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified&raiseExceptionOnSilentRollback=false'
               spring_datasource_username: postgres
               spring_datasource_password: pass
-              spring_liquibase_parameters_userTableQuote: '"'
               EXCLUDED_TEST_GROUPS: org.airsonic.player.util.EmbeddedTestCategory
           - jdk: 11
             services:
@@ -89,7 +87,6 @@ jobs:
               spring_datasource_url: 'jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified&raiseExceptionOnSilentRollback=false'
               spring_datasource_username: postgres
               spring_datasource_password: pass
-              spring_liquibase_parameters_userTableQuote: '"'
               EXCLUDED_TEST_GROUPS: org.airsonic.player.util.EmbeddedTestCategory
           #TODO for mysql,mariadb: add collation: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin when supported by github actions on services and remove the manual run commands
           - jdk: 11

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The following property names have been changed from 10.6 to recent snapshots of 
 
 Other properties are obsolete and have been removed:
   - `DatabaseConfigType`
+  - `DatabaseUsertableQuote` (now self-managed)
 
 First migration to 11.x will create a backup DB next to the DB folder. It will be marked as `db.backup.<timestamp>`. Use this folder as the DB if a revert to an older major version is needed (11.0 -> 10.6.0).
 

--- a/airsonic-main/src/main/java/org/airsonic/player/command/DatabaseSettingsCommand.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/command/DatabaseSettingsCommand.java
@@ -12,7 +12,6 @@ public class DatabaseSettingsCommand {
     private String username;
     private String JNDIName;
     private int mysqlVarcharMaxlength;
-    private String usertableQuote;
     private String importFolder;
     private String callback;
     private boolean backuppable;
@@ -73,14 +72,6 @@ public class DatabaseSettingsCommand {
 
     public void setMysqlVarcharMaxlength(int mysqlVarcharMaxlength) {
         this.mysqlVarcharMaxlength = mysqlVarcharMaxlength;
-    }
-
-    public String getUsertableQuote() {
-        return usertableQuote;
-    }
-
-    public void setUsertableQuote(String usertableQuote) {
-        this.usertableQuote = usertableQuote;
     }
 
     public String getImportFolder() {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DatabaseSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DatabaseSettingsController.java
@@ -144,7 +144,6 @@ public class DatabaseSettingsController {
         command.setUsername(settingsService.getDatabaseUsername());
         command.setJNDIName(settingsService.getDatabaseJNDIName());
         command.setMysqlVarcharMaxlength(settingsService.getDatabaseMysqlVarcharMaxlength());
-        command.setUsertableQuote(settingsService.getDatabaseUsertableQuote());
 
         if (StringUtils.isNotBlank(command.getJNDIName())) {
             command.setConfigType(DataSourceConfigType.JNDI);
@@ -185,7 +184,6 @@ public class DatabaseSettingsController {
             }
             if (command.getConfigType() != DataSourceConfigType.BUILTIN) {
                 settingsService.setDatabaseMysqlVarcharMaxlength(command.getMysqlVarcharMaxlength());
-                settingsService.setDatabaseUsertableQuote(command.getUsertableQuote());
             }
             settingsService.setDbBackupInterval(command.getDbBackupInterval());
             settingsService.setDbBackupRetentionCount(command.getDbBackupRetentionCount());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -159,7 +159,6 @@ public class SettingsService {
     public static final String KEY_DATABASE_JNDI_NAME = "spring.datasource.jndi-name";
     private static final String KEY_DATABASE_MIGRATION_ROLLBACK_FILE = "spring.liquibase.rollback-file";
     private static final String KEY_DATABASE_MIGRATION_PARAMETER_MYSQL_VARCHAR_MAXLENGTH = "spring.liquibase.parameters.mysqlVarcharLimit";
-    public static final String KEY_DATABASE_MIGRATION_PARAMETER_USERTABLE_QUOTE = "spring.liquibase.parameters.userTableQuote";
     private static final String KEY_DATABASE_MIGRATION_PARAMETER_DEFAULT_MUSIC_FOLDER = "spring.liquibase.parameters.defaultMusicFolder";
 
     public static final String KEY_PROPERTIES_FILE_RETAIN_OBSOLETE_KEYS = "PropertiesFileRetainObsoleteKeys";
@@ -255,7 +254,6 @@ public class SettingsService {
     private static final String DEFAULT_DATABASE_PASSWORD = null;
     private static final String DEFAULT_DATABASE_JNDI_NAME = null;
     private static final Integer DEFAULT_DATABASE_MIGRATION_PARAMETER_MYSQL_VARCHAR_MAXLENGTH = 384;
-    private static final String DEFAULT_DATABASE_MIGRATION_PARAMETER_USERTABLE_QUOTE = "";
 
     private static final String LOCALES_FILE = "/org/airsonic/player/i18n/locales.txt";
     private static final String THEMES_FILE = "/org/airsonic/player/theme/themes.txt";
@@ -291,7 +289,8 @@ public class SettingsService {
             "CoverArtFileTypes", "UrlRedirectCustomHost", "CoverArtLimit", "StreamPort",
             "PortForwardingEnabled", "RewriteUrl", "UrlRedirectCustomUrl", "UrlRedirectContextPath",
             "UrlRedirectFrom", "UrlRedirectionEnabled", "UrlRedirectType", "Port", "HttpsPort",
-            "MediaLibraryStatistics", "LastScanned", "database.config.type", "DatabaseConfigType"
+            "MediaLibraryStatistics", "LastScanned", "database.config.type", "DatabaseConfigType",
+            "database.usertable.quote", "DatabaseUsertableQuote", "spring.liquibase.parameters.userTableQuote"
             );
 
     public static Map<String, String> getMigratedPropertyKeys() {
@@ -315,9 +314,6 @@ public class SettingsService {
 
         keyMaps.put("database.varchar.maxlength", "DatabaseMysqlMaxlength");
         keyMaps.put("DatabaseMysqlMaxlength", KEY_DATABASE_MIGRATION_PARAMETER_MYSQL_VARCHAR_MAXLENGTH);
-
-        keyMaps.put("database.usertable.quote", "DatabaseUsertableQuote");
-        keyMaps.put("DatabaseUsertableQuote", KEY_DATABASE_MIGRATION_PARAMETER_USERTABLE_QUOTE);
 
         keyMaps.put("airsonic.rememberMeKey", KEY_REMEMBER_ME_KEY);
         keyMaps.put("IgnoreFileTimestamps", KEY_FULL_SCAN);
@@ -387,11 +383,6 @@ public class SettingsService {
             defaultConstants.put(
                     KEY_DATABASE_MIGRATION_PARAMETER_MYSQL_VARCHAR_MAXLENGTH,
                     DEFAULT_DATABASE_MIGRATION_PARAMETER_MYSQL_VARCHAR_MAXLENGTH.toString());
-        }
-        if (StringUtils.isBlank(env.getProperty(KEY_DATABASE_MIGRATION_PARAMETER_USERTABLE_QUOTE))) {
-            defaultConstants.put(
-                    KEY_DATABASE_MIGRATION_PARAMETER_USERTABLE_QUOTE,
-                    DEFAULT_DATABASE_MIGRATION_PARAMETER_USERTABLE_QUOTE);
         }
         if (StringUtils.isBlank(env.getProperty(KEY_DATABASE_MIGRATION_PARAMETER_DEFAULT_MUSIC_FOLDER))) {
             defaultConstants.put(KEY_DATABASE_MIGRATION_PARAMETER_DEFAULT_MUSIC_FOLDER, Util.getDefaultMusicFolder());
@@ -1715,14 +1706,6 @@ public class SettingsService {
         setInt(KEY_DATABASE_MIGRATION_PARAMETER_MYSQL_VARCHAR_MAXLENGTH, maxlength);
     }
 
-    public String getDatabaseUsertableQuote() {
-        return getString(KEY_DATABASE_MIGRATION_PARAMETER_USERTABLE_QUOTE, DEFAULT_DATABASE_MIGRATION_PARAMETER_USERTABLE_QUOTE);
-    }
-
-    public void setDatabaseUsertableQuote(String usertableQuote) {
-        setString(KEY_DATABASE_MIGRATION_PARAMETER_USERTABLE_QUOTE, usertableQuote);
-    }
-
     public String getJWTKey() {
         return getString(KEY_JWT_KEY, DEFAULT_JWT_KEY);
     }
@@ -1782,7 +1765,6 @@ public class SettingsService {
         setDatabaseUsername(DEFAULT_DATABASE_USERNAME);
         setDatabaseJNDIName(DEFAULT_DATABASE_JNDI_NAME);
         setDatabaseMysqlVarcharMaxlength(DEFAULT_DATABASE_MIGRATION_PARAMETER_MYSQL_VARCHAR_MAXLENGTH);
-        setDatabaseUsertableQuote(DEFAULT_DATABASE_MIGRATION_PARAMETER_USERTABLE_QUOTE);
     }
 
     String getPlaylistExportFormat() {

--- a/airsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -10,7 +10,8 @@
     <property name="json_type" value="json"/>
     <property name="varchar_type" dbms="mariadb,mysql" value="varchar(${mysqlVarcharLimit})" />
     <property name="varchar_type" value="varchar" />
-    <property name="userTableQuote" dbms="postgresql" value='"' /> 
+    <property name="userTableQuote" dbms="hsqldb,mariadb,mysql" value="" />
+    <property name="userTableQuote" dbms="postgresql" value="&quot;" />
     <include file="legacy/legacy-changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.2/changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.3/changelog.xml" relativeToChangelogFile="true"/>

--- a/airsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -10,6 +10,7 @@
     <property name="json_type" value="json"/>
     <property name="varchar_type" dbms="mariadb,mysql" value="varchar(${mysqlVarcharLimit})" />
     <property name="varchar_type" value="varchar" />
+    <property name="userTableQuote" dbms="postgresql" value='"' /> 
     <include file="legacy/legacy-changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.2/changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.3/changelog.xml" relativeToChangelogFile="true"/>

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_bg.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_bg.properties
@@ -523,7 +523,6 @@ usersettings.ok=\u041F\u0430\u0440\u043E\u043B\u0430\u0442\u0430 \u0435 \u0443\u
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ca.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ca.properties
@@ -523,7 +523,6 @@ usersettings.ok=L'usuari {0} ha canviat la contrasenya correctament.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_cs.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_cs.properties
@@ -523,7 +523,6 @@ usersettings.ok=Heslo u\u017Eivatele {0} bylo \u00FAsp\u011B\u0161n\u011B zm\u01
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_da.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_da.properties
@@ -609,7 +609,6 @@ credentialsettings.immutable=Bem\u00E6rk: Legitimationsoplysninger er uforanderl
 databasesettings.moreinfo=Yderligere info om databaseindstillinger, der findes i <a href="https://airsonic.github.io/docs/database/">database dokumentation</a>.
 databasesettings.configtype=Database Forbindelse Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum L\u00E6ngde
-databasesettings.usertablequote=Bruger table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=S\u00F8rg for, at du har din databasedriver i din <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.embeddriver=JDBC driver for Java classname
@@ -737,8 +736,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Legacy vil som standard v\u00E6re en indbygget H2-database, som er den bagudkompatible indstilling. Integreret JDBC opretter forbindelse til en JDBC-database med de medf\u00F8lgende indstillinger. JNDI vil finde en DataSource-forbindelse, der allerede er konfigureret i din applikationsbeholder.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max L\u00E6ngde
 helppopup.mysqlvarcharmaxlength.text=MySQL har en maksimal r\u00E6kkevidde, og som s\u00E5dan skal varchar-kolonnen bindes. Den indtastede v\u00E6rdi er den maksimale kolonnest\u00F8rrelse.
-helppopup.usertablequote.title=Bruger Table Quote
-helppopup.usertablequote.text=Airsonic-brugertabellen kaldes bruger. Dette kan resultere i en s\u00F8geordskonflikt med nogle databasesystemer. Indkapsling af det i dobbelt citater (") fungerer for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=Et JNDI-navn til at finde en datakilde af typen javax.sql.DataSource. Det oprettes i din applikationsbeholder (i.e. Tomcat).
 helppopup.jdbcdriver.title=e=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_de.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_de.properties
@@ -523,7 +523,6 @@ usersettings.ok=Passwort erfolgreich ge\u00E4ndert f\u00FCr {0}.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_el.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_el.properties
@@ -523,7 +523,6 @@ usersettings.ok=\u039F \u03BA\u03C9\u03B4\u03B9\u03BA\u03CC\u03C2 \u03C0\u03C1\u
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
@@ -654,7 +654,6 @@ credentialsettings.immutable=Note: Credentials are immutable. They can only be a
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -793,8 +792,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en_GB.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en_GB.properties
@@ -523,7 +523,6 @@ usersettings.ok=Password changed for user {0}.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_es.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_es.properties
@@ -523,7 +523,6 @@ usersettings.ok=El usuario {0} ha cambiado la contrase&ntilde;a correctamente.
 databasesettings.moreinfo=Informaci\u00F3n adicional sobre los ajustes de la base de datos puede consultarse en <a href="https://airsonic.github.io/docs/database/">documentaci\u00F3n de la base de datos</a>.
 databasesettings.configtype=Conexi\u00F3n origen de la base de datos
 databasesettings.mysqlvarcharmaxlength=Longitud m\u00E1xima "varchar" de MySQL
-databasesettings.usertablequote=Tabla de usuarios
 databasesettings.jndiname=Data Source JNDI Lookup Name
 databasesettings.jdbclibrary=Por favor, aseg\u00FArate de que tienes el controlador de tu base de datos en tu <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC Driver Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=El valor predeterminado ser\u00E1 una base de datos HSQL en la carpeta de inicio, que es la opci\u00F3n compatible hacia atr\u00E1s. Externo se conectar\u00E1 con una base de datos JDBC usando los ajustes que se hayan especificado. JNDI buscar\u00E1 una conexi\u00F3n a una fuente de datos ya configurada en el contenedor de tu aplicaci\u00F3n.
 helppopup.mysqlvarcharmaxlength.title=Longitud m\u00E1xima de "varchar" de MySQL
 helppopup.mysqlvarcharmaxlength.text=MySQL tiene una longitud m\u00E1xima de fila y por lo tanto necesita que las columnas "varchar" est\u00E9n delimitadas. El valor introducido aqu\u00ED ser\u00E1 el tama\u00F1o m\u00E1ximo de la columna.
-helppopup.usertablequote.title=Tabla de usuarios
-helppopup.usertablequote.text=La tabla de usuarios de Airsonic se llama "user". Esto puede causar un conflicto con alguna palabra clave en algunas bases de datos, como Postgres. De modo que, para Postgres, querr\u00E1s usar aqu\u00ED el car\u00E1cter de comillas dobles (").
 helppopup.jndiname.title=Data Source JNDI Lookup Name
 helppopup.jndiname.text=Un nombre JNDI para localizar la fuente de datos de tipo javax.sql.DataSource. Esto es algo que es creado en el contenedor de tu aplicaci\u00F3n (por ejemplo, Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_et.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_et.properties
@@ -523,7 +523,6 @@ usersettings.ok=Kasutaja {0} parool on edukalt muudetud.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_fi.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_fi.properties
@@ -523,7 +523,6 @@ usersettings.ok=Salasana onnistuneesti vaihdettu k\u00E4ytt\u00E4j\u00E4lle {0}.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_fr.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_fr.properties
@@ -530,7 +530,6 @@ usersettings.ok=Mot de passe modifi\u00e9 avec succ\u00e8s {0}.
 databasesettings.moreinfo=Informations compl\u00e9mentaires sur les param\u00e8tres de la base de donn\u00e9es, \u00e0 trouver dans la <a href="https://airsonic.github.io/docs/database/">documentation de la base de donn\u00e9es</a>.
 databasesettings.configtype=Source connexion base de donn\u00e9es
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Longueur maximale
-databasesettings.usertablequote=Table utilisateur
 databasesettings.jndiname=Nom de recherche pour JNDI-datasource
 databasesettings.jdbclibrary=Veuillez vous assurer que vous avez votre pilote de base de donn\u00e9es dans votre <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=Pilote JDBC pour nom de class Java
@@ -656,8 +655,6 @@ helppopup.databaseConfigType.title=Type de configuration de source de donn\u00e9
 helppopup.databaseConfigType.text=Built-in sera par d\u00e9faut une base de donn\u00e9es HSQL dans le dossier de base, qui est l'option de compatibilit\u00e9 ascendante. Externe se connectera \u00e0 une base de donn\u00e9es JDBC avec les param\u00e8tres fournis. JNDI recherchera une connexion DataSource d\u00e9j\u00e0 configur\u00e9e dans votre conteneur d'applications.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Longueur
 helppopup.mysqlvarcharmaxlength.text=MySQL a une longueur de ligne maximale et n\u00e9cessite donc de lier les colonnes varchar. La valeur entr\u00e9e ici sera la taille de colonne maximale.
-helppopup.usertablequote.title=Table utilisateur
-helppopup.usertablequote.text=La table des utilisateurs Airsonic est nomm\u00e9e user. Ceci peut g\u00e9n\u00e9rer un conflit avec certains syst\u00e8mes de base de donn\u00e9es. Encadrer par des guillemets (") fonctionne dans PostgreSQL.
 helppopup.jndiname.title=Nom de recherche pour JNDI-datasource
 helppopup.jndiname.text=Un nom JNDI pour rechercher une source de donn\u00e9es de type javax.sql.DataSource. Il est cr\u00e9\u00e9 dans votre conteneur d'application (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_is.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_is.properties
@@ -523,7 +523,6 @@ usersettings.ok=Lykilor\u00F0i Breytt fyrir Notanda {0}.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_it.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_it.properties
@@ -523,7 +523,6 @@ usersettings.ok=La password \u00E8 stata cambiata con successo per l'utente {0}.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ja_JP.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ja_JP.properties
@@ -523,7 +523,6 @@ usersettings.ok=\u30E6\u30FC\u30B6 {0} \u306E\u30D1\u30B9\u30EF\u30FC\u30C9\u309
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ko.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ko.properties
@@ -523,7 +523,6 @@ usersettings.ok={0}\uC758 \uC554\uD638\uAC00 \uC131\uACF5\uC801\uC73C\uB85C \uBC
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_mk.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_mk.properties
@@ -523,7 +523,6 @@ usersettings.ok=\u041B\u043E\u0437\u0438\u043D\u043A\u0430\u0430\u0442 \u043D\u0
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_nl.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_nl.properties
@@ -523,7 +523,6 @@ usersettings.ok=Wachtwoord gewijzigd voor gebruiker {0}.
 databasesettings.moreinfo=Extra informatie over databankinstellingen, zoals te vinden in de <a href="https://airsonic.github.io/docs/database/">databankdocumentatie</a>.
 databasesettings.configtype=Databank-verbindingsbron
 databasesettings.mysqlvarcharmaxlength=Maximale lengte van MySQL-varchar
-databasesettings.usertablequote=Quotum van gebruikerstabel
 databasesettings.jndiname=Naam opzoeken van JNDI-gegevensbron
 databasesettings.jdbclibrary=Zorg ervoor dat je je databankstuurprogramma hebt opgegeven in je <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpad</a>
 databasesettings.driver=JDBC-stuurprogramma voor Java-classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Configuratietype van gegevensbron
 helppopup.databaseConfigType.text=Ingebouwd gaat standaard naar een HSQL-databank in de thuismap, welke achterwaarts compatibel is. External verbindt met een JDBC-databank middels de opgegeven instellingen. JNDI zoekt naar een reeds ingestelde DataSource-verbinding.
 helppopup.mysqlvarcharmaxlength.title=Maximale lengte van MySQL-varchar
 helppopup.mysqlvarcharmaxlength.text=MySQL heeft een maximale rijlengte; daarom moet het aantal varchar-kolommen worden opgegeven. De hier ingevoerde waarde wordt de maximale kolomgrootte.
-helppopup.usertablequote.title=Quotum van gebruikerstabel
-helppopup.usertablequote.text=De Airsonic-gebruikerstabel heet 'user'. Op sommige systemen kan dit leiden tot sleutelwoordconflicten. Het toevoegen van dubbele aanhalingstekens (") lost dit op bij PostgreSQL.
 helppopup.jndiname.title=Naam opzoeken van JNDI-gegevensbron
 helppopup.jndiname.text=Een JNDI-naam waarmee een gegevensbron wordt opgezocht voor javax.sql.DataSource.\u00a0Deze is gecre\u00eberd in je applicatiecontainer (bijv. Tomcat).
 helppopup.jdbcdriver.title=JDBC-stuurprogramma voor Java-classname

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_nn.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_nn.properties
@@ -523,7 +523,6 @@ usersettings.ok=Passordet for brukaren {0} er endra.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_no.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_no.properties
@@ -523,7 +523,6 @@ usersettings.ok=Passordet for bruker {0} er endret.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pl.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pl.properties
@@ -523,7 +523,6 @@ usersettings.ok=Pomy\u015Blnie zmieniono has\u0142o dla u\u017Cytkownika {0}.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pt.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pt.properties
@@ -523,7 +523,6 @@ usersettings.ok=Senha alterada com sucesso para o utilizador {0}.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pt_BR.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pt_BR.properties
@@ -515,7 +515,6 @@ usersettings.ok=Senha alterada para o usuário {0}.
 databasesettings.moreinfo=Mais informações sobre banco de dados podem ser encontradas na <a href="https://airsonic.github.io/docs/database/"> documentação de banco de dados</a>.
 databasesettings.configtype=Fonte de Conexão do Banco de Dados
 databasesettings.mysqlvarcharmaxlength=Tamanho Máximo do Varchar MySQL
-databasesettings.usertablequote=Tabela de Cota de Usuário
 databasesettings.jndiname=Nome de pesquisa para a origem de dados JNDI
 databasesettings.jdbclibrary=Assegure-se de ter o driver de banco de dados <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=Driver JDBC para Java classname
@@ -631,8 +630,6 @@ helppopup.databaseConfigType.title=Tipo de Configuração da Fonte de Dados
 helppopup.databaseConfigType.text=Built-in será o padrão para um banco de dados HSQL, que é a opção compatível com versões anteriores. O External se conectará a um banco de dados JDBC. O JNDI procurará uma conexão DataSource já configurada no contêiner de seu aplicativo.
 helppopup.mysqlvarcharmaxlength.title=Tamanho Máximo do Varchar MySQL
 helppopup.mysqlvarcharmaxlength.text=O MySQL tem um comprimento máximo de linhas e precisa de colunas varchar para serem ligadas. O valor inserido aqui será o tamanho máximo da coluna.
-helppopup.usertablequote.title=Tabela de Usuário Quote
-helppopup.usertablequote.text=A tabela do usuário Airsonic é chamada de user. Isso pode resultar em um conflito de palavras-chave com alguns bancos de dados. Colocá-lo entre aspas duplas funciona para o PostgreSQL
 helppopup.jndiname.title=Nome da Pesquisa para Fonte de Dados JNDI
 helppopup.jndiname.text=Um nome JNDI para procurar uma origem de dados do tipo javax.sql.DataSource. Ele é criado em seu contêiner de aplicativos (por exemplo, Tomcat).
 helppopup.jdbcdriver.title=Classe de Driver JDBC

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pt_PT.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_pt_PT.properties
@@ -523,7 +523,6 @@ usersettings.ok=Password changed for user {0}.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ru.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_ru.properties
@@ -523,7 +523,6 @@ usersettings.ok=\u041F\u0430\u0440\u043E\u043B\u044C \u0438\u0437\u043C\u0435\u0
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_sl.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_sl.properties
@@ -523,7 +523,6 @@ usersettings.ok=Geslo uporabnika {0} uspe\u0161no spremenjeno.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_sv.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_sv.properties
@@ -523,7 +523,6 @@ usersettings.ok=L\u00F6senordsbytet lyckades f\u00F6r anv\u00E4ndare {0}.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_uk.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_uk.properties
@@ -523,7 +523,6 @@ usersettings.ok=Password changed for user {0}.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_zh_CN.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_zh_CN.properties
@@ -523,7 +523,6 @@ usersettings.ok=\u7528\u6237 {0}\u7684\u5BC6\u7801\u5DF2\u7ECF\u4FEE\u6539.
 databasesettings.moreinfo=Additional info about database settings, to be found in the <a href="https://airsonic.github.io/docs/database/">database documentation</a>.
 databasesettings.configtype=Database Connection Source
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Lookup name for JNDI-datasource
 databasesettings.jdbclibrary=Please ensure that you have your database driver in your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC driver for Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length, and as such needs varchar columns to be bound. The value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic user table is named user. This may result in a keyword conflict with some database systems. Encasing it in double quotes (") works for PostgreSQL
 helppopup.jndiname.title=Lookup Name for JNDI Data Source
 helppopup.jndiname.text=A JNDI name to look up a data source of type javax.sql.DataSource. It is created in your application container (i.e. Tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_zh_TW.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_zh_TW.properties
@@ -523,7 +523,6 @@ usersettings.ok=\u4F7F\u7528\u8005 {0} \u7684\u5BC6\u78BC\u5DF2\u7D93\u8B8A\u66F
 databasesettings.moreinfo=Additional information on database settings can be read at <a href="https://github.com/airsonic/airsonic/blob/develop/documentation/DATABASE.md">DATABASE.md</a> on the Airsonic github page.
 databasesettings.configtype=\u8CC7\u6599\u5EAB\u9023\u7DDA\u4F86\u6E90
 databasesettings.mysqlvarcharmaxlength=MySQL Varchar Maximum Length
-databasesettings.usertablequote=User table Quote
 databasesettings.jndiname=Data Source JNDI Lookup Name
 databasesettings.jdbclibrary=Please ensure that you have your database driver on your <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html">Java Classpath</a>
 databasesettings.driver=JDBC Driver Java classname
@@ -649,8 +648,6 @@ helppopup.databaseConfigType.title=Data Source Config Type
 helppopup.databaseConfigType.text=Built-in will default to an HSQL database in the home folder, which is the backwards compatible option. External will connect to a JDBC database with the provided settings. JNDI will look up a DataSource connection already set up in your application container.
 helppopup.mysqlvarcharmaxlength.title=MySQL Varchar Max Length
 helppopup.mysqlvarcharmaxlength.text=MySQL has a maximum row length and as such needs varchar columns to be bounded. This value entered here will be the maximum column size.
-helppopup.usertablequote.title=User Table Quote
-helppopup.usertablequote.text=The Airsonic users table is named user. This may be a keyword conflict in some databases such as Postgres. So for postgres, you will want to use the double quote character (") here
 helppopup.jndiname.title=Data Source JNDI Lookup Name
 helppopup.jndiname.text=A JNDI name to lookup a Data Source of type javax.sql.DataSource. This is something that iscreated in your application container (i.e. tomcat).
 helppopup.jdbcdriver.title=JDBC Driver Class

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/databaseSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/databaseSettings.jsp
@@ -172,13 +172,6 @@
                     <c:import url="helpToolTip.jsp"><c:param name="topic" value="mysqlvarcharmaxlength"/></c:import>
                 </td>
             </tr>
-            <tr>
-                <td><fmt:message key="databasesettings.usertablequote"/></td>
-                <td>
-                    <form:input path="usertableQuote" size="1" htmlEscape="true"/>
-                    <c:import url="helpToolTip.jsp"><c:param name="topic" value="usertablequote"/></c:import>
-                </td>
-            </tr>
         </table>
         <p class="warning"><fmt:message key="databasesettings.jdbclibrary"/></p>
     </div>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -155,7 +155,6 @@
                                             <spring_datasource_url>${env.spring_datasource_url}</spring_datasource_url>
                                             <spring_datasource_username>${env.spring_datasource_username}</spring_datasource_username>
                                             <spring_datasource_password>${env.spring_datasource_password}</spring_datasource_password>
-                                            <spring_liquibase_parameters_userTableQuote>${env.spring_liquibase_parameters_userTableQuote}</spring_liquibase_parameters_userTableQuote>
                                         </env>
                                         <volumes>
                                             <bind>


### PR DESCRIPTION
This change removes the user-visible "User table quote" from Settings->Database while leaving the actual setting in place for legacy migration purposes.
