### PR TITLE
Support CUE-indexed tracks - "The Return of the CUE File"

### DIFF
--- a/airsonic-main/pom.xml
+++ b/airsonic-main/pom.xml
@@ -513,7 +513,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jaxb-annotations</artifactId>
-         </dependency>
+        </dependency>
+        <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>64.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.digitalmediaserver</groupId>
+            <artifactId>cuelib-core</artifactId>
+            <version>2.0.0</version>
+        </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>jakarta.mail</artifactId>
@@ -557,6 +567,7 @@
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/MediaFileWSController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/MediaFileWSController.java
@@ -118,6 +118,7 @@ public class MediaFileWSController {
                 .concat(Optional.ofNullable(paths).orElse(Collections.emptyList()).parallelStream().map(mediaFileService::getMediaFile),
                         Optional.ofNullable(ids).orElse(Collections.emptyList()).parallelStream().map(mediaFileService::getMediaFile))
                 .filter(Objects::nonNull)
+                .filter(x -> mediaFileService.showMediaFile(x))
                 .collect(Collectors.toList());
     }
 
@@ -154,7 +155,7 @@ public class MediaFileWSController {
             if (mediaFile.isFile()) {
                 mediaFile = mediaFileService.getParentOf(mediaFile);
             }
-            result.addAll(mediaFileService.getChildrenOf(mediaFile, true, true, true));
+            result.addAll(mediaFileService.getVisibleChildrenOf(mediaFile, true, true));
         }
         return new ArrayList<>(result);
     }

--- a/airsonic-main/src/main/java/org/airsonic/player/command/MusicFolderSettingsCommand.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/command/MusicFolderSettingsCommand.java
@@ -47,6 +47,7 @@ public class MusicFolderSettingsCommand {
     private String uploadsFolder;
     private String excludePatternString;
     private boolean ignoreSymLinks;
+    private boolean hideIndexedFiles;
     private Boolean fullScan;
     private Boolean clearFullScanSettingAfterScan;
 
@@ -116,6 +117,14 @@ public class MusicFolderSettingsCommand {
 
     public boolean getIgnoreSymLinks() {
         return ignoreSymLinks;
+    }
+
+    public boolean getHideIndexedFiles() {
+        return hideIndexedFiles;
+    }
+
+    public void setHideIndexedFiles(boolean hideIndexedFiles) {
+        this.hideIndexedFiles = hideIndexedFiles;
     }
 
     public void setIgnoreSymLinks(boolean ignoreSymLinks) {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/ExternalPlayerController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/ExternalPlayerController.java
@@ -124,7 +124,7 @@ public class ExternalPlayerController {
                     .filter(f -> Files.exists(f.getFullPath(mediaFolderService.getMusicFolderById(f.getFolderId()).getPath())))
                     .flatMap(f -> {
                         if (f.isDirectory()) {
-                            return mediaFileService.getChildrenOf(f, true, false, true).stream()
+                            return mediaFileService.getVisibleChildrenOf(f, false, true).stream()
                                     .map(fc -> addUrlInfo(request, player, fc, expires));
                         } else {
                             return Stream.of(addUrlInfo(request, player, f, expires));

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/HLSController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/HLSController.java
@@ -68,6 +68,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.awt.*;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -116,7 +117,9 @@ public class HLSController {
 
     @PostConstruct
     public void init() {
-        FileUtil.delete(HlsSession.getHlsRootDirectory());
+        if (Files.exists(HlsSession.getHlsRootDirectory())) {
+            FileUtil.delete(HlsSession.getHlsRootDirectory());
+        }
     }
 
     @GetMapping("/hls.m3u8")

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/MusicFolderSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/MusicFolderSettingsController.java
@@ -104,6 +104,7 @@ public class MusicFolderSettingsController {
         command.setUploadsFolder(settingsService.getUploadsFolder());
         command.setExcludePatternString(settingsService.getExcludePatternString());
         command.setIgnoreSymLinks(settingsService.getIgnoreSymLinks());
+        command.setHideIndexedFiles(settingsService.getHideIndexedFiles());
         command.setFullScan(settingsService.getFullScan());
         command.setClearFullScanSettingAfterScan(!settingsService.getFullScan() ? settingsService.getFullScan() : settingsService.getClearFullScanSettingAfterScan());
 
@@ -178,6 +179,7 @@ public class MusicFolderSettingsController {
         settingsService.setUploadsFolder(command.getUploadsFolder());
         settingsService.setExcludePatternString(command.getExcludePatternString());
         settingsService.setIgnoreSymLinks(command.getIgnoreSymLinks());
+        settingsService.setHideIndexedFiles(command.getHideIndexedFiles());
         settingsService.setFullScan(command.getFullScan());
         settingsService.setClearFullScanSettingAfterScan(!command.getFullScan() ? command.getFullScan() : command.getClearFullScanSettingAfterScan());
         settingsService.save();

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/ShareManagementController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/ShareManagementController.java
@@ -103,7 +103,7 @@ public class ShareManagementController {
             if (indexes.length == 0) {
                 return Arrays.asList(album);
             }
-            List<MediaFile> children = mediaFileService.getChildrenOf(album, true, false, true);
+            List<MediaFile> children = mediaFileService.getVisibleChildrenOf(album, false, true);
             for (int index : indexes) {
                 result.add(children.get(index));
             }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -660,7 +660,7 @@ public class SubsonicRESTController {
             directory.setUserRating(ratingService.getRatingForUser(username, dir));
         }
 
-        for (MediaFile child : mediaFileService.getChildrenOf(dir, true, true, true)) {
+        for (MediaFile child : mediaFileService.getVisibleChildrenOf(dir, true, true)) {
             directory.getChild().add(createJaxbChild(player, child, username));
         }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/TranscodingSettingsController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/TranscodingSettingsController.java
@@ -57,6 +57,8 @@ public class TranscodingSettingsController {
 
         map.put("transcodings", transcodingService.getAllTranscodings());
         map.put("transcodeDirectory", SettingsService.getTranscodeDirectory());
+        map.put("splitOptions", settingsService.getSplitOptions());
+        map.put("splitCommand", settingsService.getSplitCommand());
         map.put("downsampleCommand", settingsService.getDownsamplingCommand());
         map.put("hlsCommand", settingsService.getHlsCommand());
         map.put("jukeboxCommand", settingsService.getJukeboxCommand());
@@ -138,6 +140,8 @@ public class TranscodingSettingsController {
                 return error;
             }
         }
+        settingsService.setSplitOptions(StringUtils.trim(request.getParameter("splitOptions")));
+        settingsService.setSplitCommand(StringUtils.trim(request.getParameter("splitCommand")));
         settingsService.setDownsamplingCommand(StringUtils.trim(request.getParameter("downsampleCommand")));
         settingsService.setHlsCommand(StringUtils.trim(request.getParameter("hlsCommand")));
         settingsService.setJukeboxCommand(StringUtils.trim(request.getParameter("jukeboxCommand")));

--- a/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
@@ -49,9 +49,9 @@ import java.util.stream.IntStream;
 @Repository
 public class MediaFileDao extends AbstractDao {
     private static final Logger LOG = LoggerFactory.getLogger(MediaFileDao.class);
-    private static final String INSERT_COLUMNS = "path, folder_id, type, format, title, album, artist, album_artist, disc_number, " +
+    private static final String INSERT_COLUMNS = "path, folder_id, type, start_position, format, title, album, artist, album_artist, disc_number, " +
                                                 "track_number, year, genre, bit_rate, variable_bit_rate, duration, file_size, width, height, cover_art_path, " +
-                                                "parent_path, play_count, last_played, comment, created, changed, last_scanned, children_last_updated, present, " +
+                                                "parent_path, index_path, play_count, last_played, comment, created, changed, last_scanned, children_last_updated, present, " +
                                                 "version, mb_release_id, mb_recording_id";
 
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
@@ -63,8 +63,12 @@ public class MediaFileDao extends AbstractDao {
     private final MusicFileInfoMapper musicFileInfoRowMapper = new MusicFileInfoMapper();
     private final GenreMapper genreRowMapper = new GenreMapper();
 
+    public MediaFile getMediaFile(String path, int folderId, Double startPosition) {
+        return queryOne("select " + QUERY_COLUMNS + " from media_file where path=? and folder_id=? and start_position=?", rowMapper, path, folderId, startPosition);
+    }
+
     public MediaFile getMediaFile(String path, int folderId) {
-        return queryOne("select " + QUERY_COLUMNS + " from media_file where path=? and folder_id=?", rowMapper, path, folderId);
+        return getMediaFile(path, folderId, MediaFile.NOT_INDEXED);
     }
 
     public MediaFile getMediaFile(int id) {
@@ -78,7 +82,21 @@ public class MediaFileDao extends AbstractDao {
      * @return The list of children.
      */
     public List<MediaFile> getChildrenOf(String path, int folderId, boolean onlyPresent) {
-        return query("select " + QUERY_COLUMNS + " from media_file where parent_path=? and folder_id=?" + (onlyPresent ? " and present" : ""), rowMapper, path, folderId);
+        return getChildrenOf(path, folderId, onlyPresent, false);
+    }
+
+    /**
+     * Returns the media file that are direct children of the given path.
+     *
+     * @param path The path.
+     * @param folderid root folder
+     * @param onlyPresent only return files which are marked as being present
+     * @param noIndexedTracks do not return indexed tracks
+     * @return The list of children.
+     */
+    public List<MediaFile> getChildrenOf(String path, int folderId, boolean onlyPresent, boolean noIndexedTracks) {
+        return query("select " + QUERY_COLUMNS + " from media_file where parent_path=? and folder_id=?" +
+                        (onlyPresent ? " and present" : "") + (noIndexedTracks ? " and start_position < 0" : ""), rowMapper, path, folderId);
     }
 
     public List<MediaFile> getFilesInPlaylist(int playlistId) {
@@ -88,11 +106,15 @@ public class MediaFileDao extends AbstractDao {
                      "order by playlist_file.id", rowMapper, playlistId);
     }
 
-    public List<MediaFile> getSongsForAlbum(String artist, String album) {
-        return query("select " + QUERY_COLUMNS + " from media_file where album_artist=? and album=? and present " +
-                     "and type in (?,?,?) order by disc_number, track_number", rowMapper,
-                     artist, album, MediaFile.MediaType.MUSIC.name(), MediaFile.MediaType.AUDIOBOOK.name(), MediaFile.MediaType.PODCAST.name());
+    public List<MediaFile> getSongsForAlbum(final String artist, final String album) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("types", MediaFile.MediaType.audioTypes());
+        args.put("artist", artist);
+        args.put("album", album);
+        return namedQuery("select " + QUERY_COLUMNS + " from media_file where album_artist = :artist and album = :album and present " +
+                          "and type in (:types) order by disc_number, track_number", rowMapper, args);
     }
+
 
     public List<MediaFile> getVideos(final int count, final int offset, final List<MusicFolder> musicFolders) {
         if (musicFolders.isEmpty()) {
@@ -122,7 +144,8 @@ public class MediaFileDao extends AbstractDao {
 
     @Transactional(isolation = Isolation.READ_COMMITTED)
     public void createOrUpdateMediaFile(MediaFile file, Consumer<MediaFile> preInsertionCallback) {
-        LOG.trace("Creating/Updating new media file at {} in folder id {}", file.getPath(), file.getFolderId());
+        LOG.trace("Creating/Updating new media file (id {}, path {}, fid {}, spos {}, dur {}, ip {}, type {})",
+                    file.getId(), file.getPath(), file.getFolderId(), file.getStartPosition(), file.getDuration(), file.getIndexPath(), file.getMediaType().name());
         String sql = null;
         if (file.getId() != null) {
             sql = "" +
@@ -130,6 +153,7 @@ public class MediaFileDao extends AbstractDao {
                     "path=:path," +
                     "folder_id=:fid," +
                     "type=:type," +
+                    "start_position=:spos," +
                     "format=:format," +
                     "title=:title," +
                     "album=:album," +
@@ -147,6 +171,7 @@ public class MediaFileDao extends AbstractDao {
                     "height=:h," +
                     "cover_art_path=:cap," +
                     "parent_path=:pp," +
+                    "index_path=:ip," +
                     "play_count=:pc," +
                     "last_played=:lp," +
                     "comment=:comment," +
@@ -178,6 +203,7 @@ public class MediaFileDao extends AbstractDao {
                     "height=:h," +
                     "cover_art_path=:cap," +
                     "parent_path=:pp," +
+                    "index_path=:ip," +
                     "play_count=:pc," +
                     "last_played=:lp," +
                     "comment=:comment," +
@@ -188,7 +214,7 @@ public class MediaFileDao extends AbstractDao {
                     "version=:ver," +
                     "mb_release_id=:mbrelid," +
                     "mb_recording_id=:mbrecid " +
-                    "where path=:path and folder_id=:fid";
+                    "where path=:path and folder_id=:fid and start_position=:spos";
         }
 
         LOG.trace("Updating media file {}", Util.debugObject(file));
@@ -197,6 +223,7 @@ public class MediaFileDao extends AbstractDao {
         args.put("path", file.getPath());
         args.put("fid", file.getFolderId());
         args.put("type", file.getMediaType().name());
+        args.put("spos", file.getStartPosition());
         args.put("format", file.getFormat());
         args.put("title", file.getTitle());
         args.put("album", file.getAlbumName());
@@ -214,6 +241,7 @@ public class MediaFileDao extends AbstractDao {
         args.put("h", file.getHeight());
         args.put("cap", file.getCoverArtPath());
         args.put("pp", file.getParentPath());
+        args.put("ip", file.getIndexPath());
         args.put("pc", file.getPlayCount());
         args.put("lp", file.getLastPlayed());
         args.put("comment", file.getComment());
@@ -232,17 +260,23 @@ public class MediaFileDao extends AbstractDao {
             preInsertionCallback.accept(file);
 
             update("insert into media_file (" + INSERT_COLUMNS + ") values (" + questionMarks(INSERT_COLUMNS) + ")",
-                   file.getPath(), file.getFolderId(), file.getMediaType().name(), file.getFormat(), file.getTitle(), file.getAlbumName(), file.getArtist(),
-                   file.getAlbumArtist(), file.getDiscNumber(), file.getTrackNumber(), file.getYear(), file.getGenre(), file.getBitRate(),
-                   file.isVariableBitRate(), file.getDuration(), file.getFileSize(), file.getWidth(), file.getHeight(),
-                   file.getCoverArtPath(), file.getParentPath(), file.getPlayCount(), file.getLastPlayed(), file.getComment(),
+                   file.getPath(), file.getFolderId(), file.getMediaType().name(), file.getStartPosition(), file.getFormat(), file.getTitle(),
+                   file.getAlbumName(), file.getArtist(), file.getAlbumArtist(), file.getDiscNumber(), file.getTrackNumber(), file.getYear(),
+                   file.getGenre(), file.getBitRate(), file.isVariableBitRate(), file.getDuration(), file.getFileSize(), file.getWidth(), file.getHeight(),
+                   file.getCoverArtPath(), file.getParentPath(), file.getIndexPath(), file.getPlayCount(), file.getLastPlayed(), file.getComment(),
                    file.getCreated(), file.getChanged(), file.getLastScanned(),
                    file.getChildrenLastUpdated(), file.isPresent(), VERSION, file.getMusicBrainzReleaseId(), file.getMusicBrainzRecordingId());
         }
 
         if (file.getId() == null) {
-            Integer id = queryForInt("select id from media_file where path=? and folder_id=?", null, file.getPath(), file.getFolderId());
-            file.setId(id);
+            try {
+                Integer id;
+                id = queryForInt("select id from media_file where path=? and folder_id=? and start_position=?",
+                                    null, file.getPath(), file.getFolderId(), file.getStartPosition());
+                file.setId(id);
+            } catch (Exception e) {
+                LOG.warn("failure getting id for mediaFile {}", file, e);
+            }
         }
     }
 
@@ -441,7 +475,7 @@ public class MediaFileDao extends AbstractDao {
             return Collections.emptyList();
         }
         Map<String, Object> args = new HashMap<>();
-        args.put("types", Arrays.asList(MediaFile.MediaType.MUSIC.name(), MediaFile.MediaType.PODCAST.name(), MediaFile.MediaType.AUDIOBOOK.name()));
+        args.put("types", MediaFile.MediaType.audioTypes());
         args.put("genre", genre);
         args.put("count", count);
         args.put("offset", offset);
@@ -450,10 +484,15 @@ public class MediaFileDao extends AbstractDao {
                 "and present and folder_id in (:folders) order by id limit :count offset :offset", rowMapper, args);
     }
 
-    public List<MediaFile> getSongsByArtist(String artist, int offset, int count) {
-        return query("select " + QUERY_COLUMNS
-                     + " from media_file where type in (?,?,?) and artist=? and present order by id limit ? offset ?",
-                     rowMapper, MediaFile.MediaType.MUSIC.name(), MediaFile.MediaType.PODCAST.name(), MediaFile.MediaType.AUDIOBOOK.name(), artist, count, offset);
+    public List<MediaFile> getSongsByArtist(final String artist, final int offset, final int count) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("types", MediaFile.MediaType.audioTypes());
+        args.put("artist", artist);
+        args.put("count", count);
+        args.put("offset", offset);
+        return namedQuery("select " + QUERY_COLUMNS + " from media_file where type in (:types) and artist = :artist " +
+                          "and present limit :count offset :offset",
+                          rowMapper, args);
     }
 
     public MediaFile getSongByArtistAndTitle(final String artist, final String title, final List<MusicFolder> musicFolders) {
@@ -538,14 +577,14 @@ public class MediaFileDao extends AbstractDao {
             return Collections.emptyList();
         }
         Map<String, Object> args = new HashMap<>();
-        args.put("types", Arrays.asList(MediaFile.MediaType.MUSIC.name(), MediaFile.MediaType.PODCAST.name(), MediaFile.MediaType.AUDIOBOOK.name(), MediaFile.MediaType.VIDEO.name()));
+        args.put("types", MediaFile.MediaType.playableTypes());
         args.put("folders", MusicFolder.toIdList(musicFolders));
         args.put("username", username);
         args.put("count", count);
         args.put("offset", offset);
-        return namedQuery("select " + prefix(QUERY_COLUMNS, "media_file") + " from starred_media_file, media_file where media_file.id = starred_media_file.media_file_id and " +
-                          "media_file.present and media_file.type in (:types) and starred_media_file.username = :username and " +
-                          "media_file.folder_id in (:folders) " +
+        return namedQuery("select " + prefix(QUERY_COLUMNS, "media_file") + " from starred_media_file, media_file " +
+                          "where media_file.id = starred_media_file.media_file_id and media_file.present and media_file.type in (:types) and " +
+                          "starred_media_file.username = :username and media_file.folder_id in (:folders) " +
                           "order by starred_media_file.created desc, starred_media_file.id limit :count offset :offset",
                           rowMapper, args);
     }
@@ -586,6 +625,7 @@ public class MediaFileDao extends AbstractDao {
         }
 
         query += " where media_file.present and media_file.type = 'MUSIC'";
+        query += " and media_file.index_path is null;"; // exclude indexed files
 
         if (!criteria.getMusicFolders().isEmpty()) {
             query += " and media_file.folder_id in (:folders)";
@@ -761,9 +801,8 @@ public class MediaFileDao extends AbstractDao {
     }
 
     public List<Integer> getSongExpungeCandidates() {
-        return queryForInts("select id from media_file where media_file.type in (?,?,?,?) and not present",
-                MediaFile.MediaType.MUSIC.name(), MediaFile.MediaType.PODCAST.name(),
-                MediaFile.MediaType.AUDIOBOOK.name(), MediaFile.MediaType.VIDEO.name());
+        return queryForInts("select id from media_file where media_file.type in (?) and not present",
+                String.join(",", MediaFile.MediaType.playableTypes()));
     }
 
     public void expunge() {
@@ -778,34 +817,36 @@ public class MediaFileDao extends AbstractDao {
                     rs.getString(2),
                     rs.getInt(3),
                     MediaFile.MediaType.valueOf(rs.getString(4)),
-                    rs.getString(5),
+                    rs.getDouble(5),
                     rs.getString(6),
                     rs.getString(7),
                     rs.getString(8),
                     rs.getString(9),
-                    rs.getInt(10) == 0 ? null : rs.getInt(10),
+                    rs.getString(10),
                     rs.getInt(11) == 0 ? null : rs.getInt(11),
                     rs.getInt(12) == 0 ? null : rs.getInt(12),
-                    rs.getString(13),
-                    rs.getInt(14) == 0 ? null : rs.getInt(14),
-                    rs.getBoolean(15),
-                    rs.getDouble(16),
-                    rs.getLong(17) == 0 ? null : rs.getLong(17),
-                    rs.getInt(18) == 0 ? null : rs.getInt(18),
+                    rs.getInt(13) == 0 ? null : rs.getInt(13),
+                    rs.getString(14),
+                    rs.getInt(15) == 0 ? null : rs.getInt(15),
+                    rs.getBoolean(16),
+                    rs.getDouble(17),
+                    rs.getLong(18) == 0 ? null : rs.getLong(18),
                     rs.getInt(19) == 0 ? null : rs.getInt(19),
-                    rs.getString(20),
+                    rs.getInt(20) == 0 ? null : rs.getInt(20),
                     rs.getString(21),
-                    rs.getInt(22),
-                    Optional.ofNullable(rs.getTimestamp(23)).map(x -> x.toInstant()).orElse(null),
-                    rs.getString(24),
+                    rs.getString(22),
+                    rs.getString(23),
+                    rs.getInt(24),
                     Optional.ofNullable(rs.getTimestamp(25)).map(x -> x.toInstant()).orElse(null),
-                    Optional.ofNullable(rs.getTimestamp(26)).map(x -> x.toInstant()).orElse(null),
+                    rs.getString(26),
                     Optional.ofNullable(rs.getTimestamp(27)).map(x -> x.toInstant()).orElse(null),
                     Optional.ofNullable(rs.getTimestamp(28)).map(x -> x.toInstant()).orElse(null),
-                    rs.getBoolean(29),
-                    rs.getInt(30),
-                    rs.getString(31),
-                    rs.getString(32));
+                    Optional.ofNullable(rs.getTimestamp(29)).map(x -> x.toInstant()).orElse(null),
+                    Optional.ofNullable(rs.getTimestamp(30)).map(x -> x.toInstant()).orElse(null),
+                    rs.getBoolean(31),
+                    rs.getInt(32),
+                    rs.getString(33),
+                    rs.getString(34));
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFileComparator.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFileComparator.java
@@ -63,6 +63,23 @@ public class MediaFileComparator implements Comparator<MediaFile> {
             return n == 0 ? a.getPath().compareToIgnoreCase(b.getPath()) : n; // To make it consistent to MediaFile.equals()
         }
 
+        // indexed tracks above non-indexed tracks
+        if (!a.isIndexedTrack() && b.isIndexedTrack()) {
+            return 1;
+        }
+
+        if (a.isIndexedTrack() && !b.isIndexedTrack()) {
+            return -1;
+        }
+
+        // keep indexed tracks together
+        if (a.isIndexedTrack() && b.isIndexedTrack()) {
+            int i = a.getPath().compareToIgnoreCase(b.getPath());
+            if (i != 0) {
+                return i;
+            }
+        }
+
         // Compare by disc and track numbers, if present.
         Integer trackA = getSortableDiscAndTrackNumber(a);
         Integer trackB = getSortableDiscAndTrackNumber(b);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -293,8 +293,6 @@ public class MediaScannerService {
             LOG.info("Scanned media library with {} entries.", scanCount.get());
         }
 
-        LOG.trace("Scanning file {} in folder {} ({})", file.getPath(), musicFolder.getId(), musicFolder.getName());
-
         // Update the root folder if it has changed
         if (!musicFolder.getId().equals(file.getFolderId())) {
             file.setFolderId(musicFolder.getId());
@@ -317,7 +315,8 @@ public class MediaScannerService {
         updateGenres(file, genres);
         encountered.putIfAbsent(file.getPath(), Boolean.TRUE);
 
-        if (file.getDuration() != null) {
+        // don't add indexed tracks to the total duration to avoid double-counting
+        if ((file.getDuration() != null) && (!file.isIndexedTrack())) {
             statistics.incrementTotalDurationInSeconds(file.getDuration());
         }
         if (file.getFileSize() != null) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MusicIndexService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MusicIndexService.java
@@ -41,7 +41,6 @@ import static java.util.stream.Collectors.toList;
  */
 @Service
 public class MusicIndexService {
-
     @Autowired
     private SettingsService settingsService;
     @Autowired

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PlayQueueService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PlayQueueService.java
@@ -167,7 +167,7 @@ public class PlayQueueService {
             boolean queueFollowingSongs = settingsService.getUserSettings(player.getUsername()).getQueueFollowingSongs();
             if (queueFollowingSongs) {
                 MediaFile dir = mediaFileService.getParentOf(file);
-                songs = mediaFileService.getChildrenOf(dir, true, false, true);
+                songs = mediaFileService.getVisibleChildrenOf(dir, false, true);
                 if (!songs.isEmpty()) {
                     int index = songs.indexOf(file);
                     songs = songs.subList(index, songs.size());
@@ -325,7 +325,7 @@ public class PlayQueueService {
 
         List<MediaFile> songs = new ArrayList<>();
         for (MediaFile album : albums) {
-            songs.addAll(mediaFileService.getChildrenOf(album, true, false, false));
+            songs.addAll(mediaFileService.getVisibleChildrenOf(album, false, false));
         }
         Collections.shuffle(songs);
         songs = songs.subList(0, Math.min(40, songs.size()));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -102,6 +102,8 @@ public class SettingsService {
     private static final String KEY_PODCAST_EPISODE_DOWNLOAD_COUNT = "PodcastEpisodeDownloadCount";
     private static final String KEY_DOWNLOAD_BITRATE_LIMIT = "DownloadBitrateLimit";
     private static final String KEY_UPLOAD_BITRATE_LIMIT = "UploadBitrateLimit";
+    private static final String KEY_SPLIT_OPTIONS = "SplitOptions";
+    private static final String KEY_SPLIT_COMMAND = "SplitCommand";
     private static final String KEY_DOWNSAMPLING_COMMAND = "DownsamplingCommand4";
     private static final String KEY_HLS_COMMAND = "HlsCommand4";
     private static final String KEY_JUKEBOX_COMMAND = "JukeboxCommand2";
@@ -142,6 +144,7 @@ public class SettingsService {
     private static final String KEY_SMTP_FROM = "SmtpFrom";
     private static final String KEY_EXPORT_PLAYLIST_FORMAT = "PlaylistExportFormat";
     private static final String KEY_IGNORE_SYMLINKS = "IgnoreSymLinks";
+    private static final String KEY_HIDE_INDEXED_FILES = "HideIndexedFiles";
     private static final String KEY_EXCLUDE_PATTERN_STRING = "ExcludePattern";
 
     private static final String KEY_CAPTCHA_ENABLED = "CaptchaEnabled";
@@ -203,7 +206,9 @@ public class SettingsService {
     private static final int DEFAULT_PODCAST_EPISODE_DOWNLOAD_COUNT = 1;
     private static final long DEFAULT_DOWNLOAD_BITRATE_LIMIT = 0;
     private static final long DEFAULT_UPLOAD_BITRATE_LIMIT = 0;
-    private static final String DEFAULT_DOWNSAMPLING_COMMAND = "ffmpeg -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -";
+    private static final String DEFAULT_SPLIT_OPTIONS = "-ss %o -t %d";
+    private static final String DEFAULT_SPLIT_COMMAND = "ffmpeg %S -i %s -vcodec copy -acodec copy -f %f -";
+    private static final String DEFAULT_DOWNSAMPLING_COMMAND = "ffmpeg %S -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -";
     private static final String DEFAULT_HLS_COMMAND = "ffmpeg -ss %o -i %s -s %wx%h -async 1 -c:v libx264 -flags +cgop -b:v %vk -maxrate %bk -preset superfast -copyts -b:a %rk -bufsize 256k -map 0:0 -map 0:%i -ac 2 -ar 44100 -v 0 -threads 0 -force_key_frames expr:gte(t,n_forced*10) -start_number %j -hls_time %d -hls_list_size 0 -hls_segment_filename %n %p";
     private static final String DEFAULT_JUKEBOX_COMMAND = "ffmpeg -ss %o -i %s -map 0:0 -v 0 -ar 44100 -ac 2 -f s16be -";
     private static final String DEFAULT_VIDEO_IMAGE_COMMAND = "ffmpeg -r 1 -ss %o -t 1 -i %s -s %wx%h -v 0 -f mjpeg -";
@@ -228,6 +233,7 @@ public class SettingsService {
     private static final String DEFAULT_SONOS_LINK_METHOD = SonosServiceRegistration.AuthenticationType.APPLICATION_LINK.name();
     private static final String DEFAULT_EXPORT_PLAYLIST_FORMAT = "m3u";
     private static final boolean DEFAULT_IGNORE_SYMLINKS = false;
+    private static final boolean DEFAULT_HIDE_INDEXED_FILES = false;
     private static final String DEFAULT_EXCLUDE_PATTERN_STRING = null;
     private static final String DEFAULT_PREFERRED_NONDECODABLE_PASSWORD_ENCODER = "bcrypt";
     private static final String DEFAULT_PREFERRED_DECODABLE_PASSWORD_ENCODER = "encrypted-AES-GCM";
@@ -270,6 +276,7 @@ public class SettingsService {
     private Set<String> cachedCoverArtFileTypes;
     private Set<String> cachedMusicFileTypes;
     private Set<String> cachedVideoFileTypes;
+    private Set<String> cachedPlayableFileTypes;
     private RateLimiter downloadRateLimiter;
     private RateLimiter uploadRateLimiter;
     private Pattern excludePattern;
@@ -649,6 +656,17 @@ public class SettingsService {
         return cachedVideoFileTypes;
     }
 
+    public Set<String> getPlayableFileTypesSet() {
+        // make sure to regenerate cached result if either KEY_VIDEO_FILE_TYPES or KEY_MUSIC_FILE_TYPES
+        // has been changed
+        if (cachedPlayableFileTypes == null
+            || cachedMusicFileTypes == null
+            || cachedVideoFileTypes == null) {
+            cachedPlayableFileTypes = splitLowerString(getMusicFileTypes().join(" ", getVideoFileTypes()), " ");
+        }
+        return cachedPlayableFileTypes;
+    }
+
     public String getCoverArtFileTypes() {
         return getProperty(KEY_COVER_ART_FILE_TYPES, DEFAULT_COVER_ART_FILE_TYPES);
     }
@@ -910,6 +928,22 @@ public class SettingsService {
         getUploadBitrateLimiter().setRate(adjustBitrateLimit(limit));
     }
 
+    public String getSplitOptions() {
+        return getProperty(KEY_SPLIT_OPTIONS, DEFAULT_SPLIT_OPTIONS);
+    }
+
+    public void setSplitOptions(String options) {
+        setProperty(KEY_SPLIT_OPTIONS, options);
+    }
+
+    public String getSplitCommand() {
+        return getProperty(KEY_SPLIT_COMMAND, DEFAULT_SPLIT_COMMAND);
+    }
+
+    public void setSplitCommand(String command) {
+        setProperty(KEY_SPLIT_COMMAND, command);
+    }
+
     public String getDownsamplingCommand() {
         return getProperty(KEY_DOWNSAMPLING_COMMAND, DEFAULT_DOWNSAMPLING_COMMAND);
     }
@@ -1043,6 +1077,14 @@ public class SettingsService {
 
     public void setIgnoreSymLinks(boolean b) {
         setBoolean(KEY_IGNORE_SYMLINKS, b);
+    }
+
+    public boolean getHideIndexedFiles() {
+        return getBoolean(KEY_HIDE_INDEXED_FILES, DEFAULT_HIDE_INDEXED_FILES);
+    }
+
+    public void setHideIndexedFiles(boolean b) {
+        setBoolean(KEY_HIDE_INDEXED_FILES, b);
     }
 
     public String getExcludePatternString() {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
@@ -181,14 +181,17 @@ public class TranscodingService {
     }
 
     /**
-     * Creates parameters for a possibly transcoded or downsampled input stream for the given media file and player combination.
-     * <p/>
+     * Creates parameters for a possibly transcoded, downsampled or split input stream for the given media file and player combination.
+     *
      * A transcoding is applied if it is applicable for the format of the given file, and is activated for the
-     * given player.
-     * <p/>
+     * given player and either the desired format or bitrate needs changing or only a section of the file should be
+     * returned.
+     *
      * If no transcoding is applicable, the file may still be downsampled, given that the player is configured
      * with a bit rate limit which is higher than the actual bit rate of the file.
-     * <p/>
+     *
+     * If neither transcoding nor downsampling is needed the file might still be split in case of indexed tracks.
+     *
      * Otherwise, a normal input stream to the original file is returned.
      *
      * @param mediaFile                The media file.
@@ -202,6 +205,7 @@ public class TranscodingService {
                                     VideoTranscodingSettings videoTranscodingSettings) {
 
         Parameters parameters = new Parameters(mediaFile, videoTranscodingSettings);
+        String suffix = mediaFile.getFormat();
 
         TranscodeScheme transcodeScheme = getTranscodeScheme(player);
         if (maxBitRate == null && transcodeScheme != TranscodeScheme.OFF) {
@@ -219,8 +223,13 @@ public class TranscodingService {
             boolean supported = isDownsamplingSupported(mediaFile);
             Integer bitRate = mediaFile.getBitRate();
             if (supported && bitRate != null && bitRate > maxBitRate) {
-                parameters.setDownsample(true);
+                parameters.setTranscoding(new Transcoding(null, "downsample", suffix, suffix, settingsService.getDownsamplingCommand(), null, null, true));
             }
+        }
+
+        // Insert split command for indexed tracks without active transcodings
+        if (mediaFile.isIndexedTrack() && parameters.getTranscoding() == null) {
+            parameters.setTranscoding(new Transcoding(null, "split", suffix, suffix, settingsService.getSplitCommand(), null, null, true));
         }
 
         parameters.setMaxBitRate(maxBitRate);
@@ -230,14 +239,16 @@ public class TranscodingService {
     }
 
     /**
-     * Returns a possibly transcoded or downsampled input stream for the given music file and player combination.
-     * <p/>
+     * Returns a possibly transcoded, downsampled and/or split input stream for the given music file and player combination.
+     *
      * A transcoding is applied if it is applicable for the format of the given file, and is activated for the
      * given player.
-     * <p/>
+     *
      * If no transcoding is applicable, the file may still be downsampled, given that the player is configured
      * with a bit rate limit which is higher than the actual bit rate of the file.
-     * <p/>
+     *
+     * If neither transcoding nor downsampling is needed the file might still be split in case of indexed tracks.
+     *
      * Otherwise, a normal input stream to the original file is returned.
      *
      * @param parameters As returned by {@link #getParameters}.
@@ -249,10 +260,6 @@ public class TranscodingService {
 
             if (parameters.getTranscoding() != null) {
                 return createTranscodedInputStream(parameters);
-            }
-
-            if (parameters.downsample) {
-                return createDownsampledInputStream(parameters);
             }
 
         } catch (IOException x) {
@@ -318,8 +325,9 @@ public class TranscodingService {
      * <li>Replacing occurrences of "%l" with the album name of the given music file.</li>
      * <li>Replacing occurrences of "%a" with the artist name of the given music file.</li>
      * <li>Replacing occurrences of "%b" with the max bitrate.</li>
-     * <li>Replacing occurrences of "%o" with the video time offset (used for scrubbing).</li>
-     * <li>Replacing occurrences of "%d" with the video duration (used for HLS).</li>
+     * <li>Replacing occurrences of "%f" with the input file format (used for indexed tracks)</li>
+     * <li>Replacing occurrences of "%o" with the time offset (used for scrubbing video and indexed tracks).</li>
+     * <li>Replacing occurrences of "%d" with the duration (used for HLS and indexed tracks).</li>
      * <li>Replacing occurrences of "%w" with the video image width.</li>
      * <li>Replacing occurrences of "%h" with the video image height.</li>
      * <li>Prepending the path of the transcoder directory if the transcoder is found there.</li>
@@ -333,7 +341,8 @@ public class TranscodingService {
      * @return The newly created input stream.
      */
     private TranscodeInputStream createTranscodeInputStream(String command, Integer maxBitRate,
-                                                            VideoTranscodingSettings videoTranscodingSettings, MediaFile mediaFile, InputStream in) throws IOException {
+                                                            VideoTranscodingSettings videoTranscodingSettings,
+                                                            MediaFile mediaFile, InputStream in) throws IOException {
 
         // Work-around for filename character encoding problem on Windows.
         // Create temporary file, and feed this to the transcoder.
@@ -348,15 +357,19 @@ public class TranscodingService {
             pathString = tmpFile.toString();
         }
 
+        // insert split sequence for indexed tracks
+        command = command.replace("%S", (mediaFile.isIndexedTrack()) ? settingsService.getSplitOptions() : "");
+
         Map<String, String> vars = generateTranscodingSubstitutionMap(
                 Optional.ofNullable(mediaFile.getTitle()).orElse("Unknown Media"),
                 Optional.ofNullable(mediaFile.getArtist()).orElse("Unknown Artist"),
                 Optional.ofNullable(mediaFile.getAlbumName()).orElse("Unknown Album"),
                 Optional.ofNullable(maxBitRate).map(String::valueOf).orElse(null),
-                videoTranscodingSettings != null ? String.valueOf(videoTranscodingSettings.getTimeOffset()) : null,
-                videoTranscodingSettings != null ? String.valueOf(videoTranscodingSettings.getDuration()) : null,
-                videoTranscodingSettings != null ? String.valueOf(videoTranscodingSettings.getWidth()) : null,
-                videoTranscodingSettings != null ? String.valueOf(videoTranscodingSettings.getHeight()) : null,
+                Optional.ofNullable(mediaFile.getFormat()).orElse(null),
+                Optional.ofNullable(videoTranscodingSettings).map(VideoTranscodingSettings::getTimeOffset).map(String::valueOf).orElse(String.valueOf(mediaFile.getStartPosition())),
+                Optional.ofNullable(videoTranscodingSettings).map(VideoTranscodingSettings::getDuration).map(String::valueOf).orElse(String.valueOf(mediaFile.getDuration())),
+                Optional.ofNullable(videoTranscodingSettings).map(VideoTranscodingSettings::getWidth).map(String::valueOf).orElse(null),
+                Optional.ofNullable(videoTranscodingSettings).map(VideoTranscodingSettings::getHeight).map(String::valueOf).orElse(null),
                 Optional.ofNullable(maxBitRate).map(TranscodingService::getAverageVideoBitRate).map(String::valueOf).orElse(null),
                 Optional.ofNullable(maxBitRate).map(TranscodingService::getSuitableAudioBitRate).map(String::valueOf).orElse(null),
                 Optional.ofNullable(videoTranscodingSettings).map(VideoTranscodingSettings::getAudioTrackIndex).map(String::valueOf).orElse(null),
@@ -399,6 +412,7 @@ public class TranscodingService {
             String artist,
             String album,
             String maxVideoBitRate,
+            String format,
             String timeOffset,
             String duration,
             String width,
@@ -415,6 +429,7 @@ public class TranscodingService {
         result.put("%a", artist);
         result.put("%l", album);
 
+        result.put("%f", format);
         result.put("%b", maxVideoBitRate);
         result.put("%o", timeOffset);
         result.put("%d", duration);
@@ -437,64 +452,51 @@ public class TranscodingService {
      * transcoding should be done.
      */
     private Transcoding getTranscoding(MediaFile mediaFile, Player player, String preferredTargetFormat, boolean hls) {
-
-        if (hls) {
-            return new Transcoding(null, "hls", mediaFile.getFormat(), "ts", settingsService.getHlsCommand(), null, null, true);
-        }
-
-        if (FORMAT_RAW.equals(preferredTargetFormat)) {
-            return null;
-        }
-
-        List<Transcoding> applicableTranscodings = new LinkedList<Transcoding>();
+        Transcoding transcoding = null;
         String suffix = mediaFile.getFormat();
 
-        // This is what I'd like todo, but this will most likely break video transcoding as video transcoding is
-        // never expected to be null
-//        if(StringUtils.equalsIgnoreCase(preferredTargetFormat, suffix)) {
-//            LOG.debug("Target formats are the same, returning no transcoding");
-//            return null;
-//        }
+        if (hls) {
+            // HLS can not be combined with cue-indexed files
+            transcoding = new Transcoding(null, "hls", mediaFile.getFormat(), "ts", settingsService.getHlsCommand(), null, null, true);
+        } else {
+            if (FORMAT_RAW.equals(preferredTargetFormat)) {
+                // RAW and cue-indexed files can be combined since the split command does not re-encode audio or video
+                transcoding = null;
+            } else {
 
-        List<Transcoding> transcodingsForPlayer = getTranscodingsForPlayer(player);
-        for (Transcoding transcoding : transcodingsForPlayer) {
-            // special case for now as video must have a transcoding
-            if (mediaFile.isVideo() && StringUtils.equalsIgnoreCase(preferredTargetFormat, transcoding.getTargetFormat())) {
-                LOG.debug("Detected source to target format match for video");
-                return transcoding;
-            }
-            for (String sourceFormat : transcoding.getSourceFormatsAsArray()) {
-                if (sourceFormat.equalsIgnoreCase(suffix)) {
-                    if (isTranscodingInstalled(transcoding)) {
-                        applicableTranscodings.add(transcoding);
+                List<Transcoding> applicableTranscodings = new LinkedList<Transcoding>();
+
+                List<Transcoding> transcodingsForPlayer = getTranscodingsForPlayer(player);
+                for (Transcoding tr : transcodingsForPlayer) {
+                    // special case for now as video must have a transcoding
+                    if (mediaFile.isVideo() && tr.getTargetFormat().equalsIgnoreCase(preferredTargetFormat) && isTranscodingInstalled(tr)) {
+                        LOG.debug("Detected source to target format match for video");
+                        applicableTranscodings.add(tr);
+                        break;
+                    }
+                    for (String sourceFormat : tr.getSourceFormatsAsArray()) {
+                        if (sourceFormat.equalsIgnoreCase(suffix) && isTranscodingInstalled(tr)) {
+                            applicableTranscodings.add(tr);
+                        }
+                    }
+                }
+
+                if (!applicableTranscodings.isEmpty()) {
+                    for (Transcoding tr : applicableTranscodings) {
+                        if (tr.getTargetFormat().equalsIgnoreCase(preferredTargetFormat)) {
+                            transcoding = tr;
+                            break;
+                        }
+                    }
+
+                    if (transcoding == null) {
+                        transcoding = applicableTranscodings.get(0);
                     }
                 }
             }
         }
 
-        if (applicableTranscodings.isEmpty()) {
-            return null;
-        }
-
-        for (Transcoding transcoding : applicableTranscodings) {
-            if (transcoding.getTargetFormat().equalsIgnoreCase(preferredTargetFormat)) {
-                return transcoding;
-            }
-        }
-
-        return applicableTranscodings.get(0);
-    }
-
-    /**
-     * Returns a downsampled input stream to the music file.
-     *
-     * @param parameters Downsample parameters.
-     * @throws IOException If an I/O error occurs.
-     */
-    private InputStream createDownsampledInputStream(Parameters parameters) throws IOException {
-        String command = settingsService.getDownsamplingCommand();
-        return createTranscodeInputStream(command, parameters.getMaxBitRate(), parameters.getVideoTranscodingSettings(),
-                parameters.getMediaFile(), null);
+        return transcoding;
     }
 
     /**
@@ -535,7 +537,7 @@ public class TranscodingService {
     private Long getExpectedLength(Parameters parameters) {
         MediaFile file = parameters.getMediaFile();
 
-        if (!parameters.isDownsample() && !parameters.isTranscode()) {
+        if (!parameters.isTranscode()) {
             return file.getFileSize();
         }
         Double duration = file.getDuration();
@@ -561,10 +563,8 @@ public class TranscodingService {
         List<String> steps = Arrays.asList();
         if (transcoding != null) {
             steps = Arrays.asList(transcoding.getStep3(), transcoding.getStep2(), transcoding.getStep1());
-        } else if (parameters.isDownsample()) {
-            steps = Arrays.asList(settingsService.getDownsamplingCommand());
         } else {
-            return true;  // neither transcoding nor downsampling
+            return true;  // no active transcodings
         }
 
         // Verify that were able to predict the length
@@ -655,7 +655,6 @@ public class TranscodingService {
     }
 
     public static class Parameters {
-        private boolean downsample;
         private Long expectedLength;
         private boolean rangeAllowed;
         private final MediaFile mediaFile;
@@ -675,14 +674,6 @@ public class TranscodingService {
 
         public void setMaxBitRate(Integer maxBitRate) {
             this.maxBitRate = maxBitRate;
-        }
-
-        public boolean isDownsample() {
-            return downsample;
-        }
-
-        public void setDownsample(boolean downsample) {
-            this.downsample = downsample;
         }
 
         public boolean isTranscode() {
@@ -726,3 +717,4 @@ public class TranscodingService {
         }
     }
 }
+

--- a/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
@@ -115,7 +115,7 @@ public class IndexManager {
         try {
             writers.get(IndexType.ALBUM_ID3).updateDocument(primarykey, document);
         } catch (Exception x) {
-            LOG.error("Failed to create search index for {}", album, x);
+            LOG.error("Failed to create search index for album {}", album, x);
         }
     }
 
@@ -125,7 +125,7 @@ public class IndexManager {
         try {
             writers.get(IndexType.ARTIST_ID3).updateDocument(primarykey, document);
         } catch (Exception x) {
-            LOG.error("Failed to create search index for {}", artist, x);
+            LOG.error("Failed to create search index for artist {}", artist, x);
         }
     }
 
@@ -143,7 +143,7 @@ public class IndexManager {
                 writers.get(IndexType.ARTIST).updateDocument(primarykey, document);
             }
         } catch (Exception x) {
-            LOG.error("Failed to create search index for {}", mediaFile, x);
+            LOG.error("Failed to create search index for mediaFile {}", mediaFile, x);
         }
     }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/sonos/SonosHelper.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/sonos/SonosHelper.java
@@ -126,7 +126,7 @@ public class SonosHelper {
         List<MediaFile> albums = searchService.getRandomAlbums(40, musicFolders);
         List<MediaFile> songs = new ArrayList<MediaFile>();
         for (MediaFile album : albums) {
-            songs.addAll(filterMusic(mediaFileService.getChildrenOf(album, true, false, false)));
+            songs.addAll(filterMusic(mediaFileService.getVisibleChildrenOf(album, false, false)));
         }
         Collections.shuffle(songs);
         songs = songs.subList(0, Math.min(count, songs.size()));
@@ -146,7 +146,7 @@ public class SonosHelper {
 
         List<MediaFile> songs = new ArrayList<MediaFile>();
         for (MediaFile album : albumList.getAlbums()) {
-            songs.addAll(filterMusic(mediaFileService.getChildrenOf(album, true, false, false)));
+            songs.addAll(filterMusic(mediaFileService.getVisibleChildrenOf(album, false, false)));
         }
         Collections.shuffle(songs);
         songs = songs.subList(0, Math.min(count, songs.size()));
@@ -221,7 +221,7 @@ public class SonosHelper {
     public List<AbstractMedia> forDirectoryContent(int mediaFileId, String username, HttpServletRequest request) {
         List<AbstractMedia> result = new ArrayList<AbstractMedia>();
         MediaFile dir = mediaFileService.getMediaFile(mediaFileId);
-        List<MediaFile> children = dir.isFile() ? Arrays.asList(dir) : mediaFileService.getChildrenOf(dir, true, true, true);
+        List<MediaFile> children = dir.isFile() ? Arrays.asList(dir) : mediaFileService.getVisibleChildrenOf(dir, true, true);
         boolean isArtist = true;
         for (MediaFile child : children) {
             if (child.isDirectory()) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/FolderBasedContentDirectory.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/FolderBasedContentDirectory.java
@@ -176,7 +176,7 @@ public class FolderBasedContentDirectory extends CustomContentDirectory {
     }
 
     private BrowseResult browseMediaFile(MediaFile mediaFile, long firstResult, long maxResults) throws Exception {
-        List<MediaFile> allChildren = mediaFileService.getChildrenOf(mediaFile, true, true, true);
+        List<MediaFile> allChildren = mediaFileService.getVisibleChildrenOf(mediaFile, true, true);
         List<MediaFile> selectedChildren = Util.subList(allChildren, firstResult, maxResults);
 
         DIDLContent didl = new DIDLContent();
@@ -223,7 +223,7 @@ public class FolderBasedContentDirectory extends CustomContentDirectory {
         Container container = mediaFile.isAlbum() ? createAlbumContainer(mediaFile) : new MusicAlbum();
         container.setId(CONTAINER_ID_FOLDER_PREFIX + mediaFile.getId());
         container.setTitle(mediaFile.getName());
-        List<MediaFile> children = mediaFileService.getChildrenOf(mediaFile, true, true, false);
+        List<MediaFile> children = mediaFileService.getVisibleChildrenOf(mediaFile, true, false);
         container.setChildCount(children.size());
 
         container.setParentID(CONTAINER_ID_ROOT);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/upnp/MediaFileUpnpProcessor.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/upnp/MediaFileUpnpProcessor.java
@@ -109,7 +109,7 @@ public class MediaFileUpnpProcessor extends UpnpContentProcessor <MediaFile, Med
 
     @Override
     public List<MediaFile> getChildren(MediaFile item) {
-        List<MediaFile> children = getMediaFileService().getChildrenOf(item, true, true, true);
+        List<MediaFile> children = getMediaFileService().getVisibleChildrenOf(item, true, true);
         children.sort((MediaFile o1, MediaFile o2) -> o1.getPath().replaceAll("\\W", "").compareToIgnoreCase(o2.getPath().replaceAll("\\W", "")));
         return children;
     }

--- a/airsonic-main/src/main/resources/liquibase/11.0/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.0/changelog.xml
@@ -22,4 +22,5 @@
     <include file="postgresql-add-rand-function.xml" relativeToChangelogFile="true"/>
     <include file="podcast-episode-guid.xml" relativeToChangelogFile="true"/>
     <include file="relative-media-file-paths.xml" relativeToChangelogFile="true"/>
+    <include file="cue-support.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/11.0/cue-support.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.0/cue-support.xml
@@ -1,0 +1,59 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="startposition_001" author="yetangitu">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="start_position" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="start_position" afterColumn="type" type="double" defaultValueNumeric="-1.0">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="dropuniqueindexfolderpath_001" author="yetangitu">
+        <dropIndex tableName="media_file" indexName="idx_media_file_folder_path" />
+        <rollback>
+            <createIndex tableName="media_file" unique="true" indexName="idx_media_file_folder_path">
+                <column name="folder_id"></column>
+                <column name="path"></column>
+            </createIndex>
+        </rollback>
+    </changeSet>
+    <changeSet id="adduniqueindexfolderpathstartposition_001" author="yetangitu">
+        <createIndex tableName="media_file" indexName="idx_media_file_folder_path_start_position" unique="true">
+            <column name="folder_id"/>
+            <column name="path"/>
+            <column name="start_position"/>
+        </createIndex>
+        <rollback>
+            <dropIndex tableName="media_file" indexName="idx_media_file_folder_path_start_position" />
+        </rollback>
+    </changeSet>
+    <changeSet id="indexpath_001" author="yetangitu">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="index_path" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="index_path" afterColumn="parent_path" type="${varchar_type}" />
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="media_file" columnName="index_path"></dropColumn>
+        </rollback>
+    </changeSet>
+    <changeSet id="addsplittingtranscoder_001" author="yetangitu">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from transcoding where name='mp3 audio' and step1 like '% %%S %'</sqlCheck>
+        </preConditions>
+        <update tableName="transcoding">
+            <column name="step1" value="ffmpeg %S -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -" />
+            <where>name='mp3 audio'</where>
+        </update>
+        <rollback changeSetId="schema50_003" changeSetAuthor="muff1nman" changeSetPath="classpath:liquibase/legacy/schema50.xml" />
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
+++ b/airsonic-main/src/main/resources/org/airsonic/player/i18n/ResourceBundle_en.properties
@@ -377,6 +377,8 @@ generalsettings.language=Default language
 generalsettings.theme=Default theme
 
 advancedsettings.downsamplecommand=Downsample command
+advancedsettings.splitoptions=Split options
+advancedsettings.splitcommand=Split command
 advancedsettings.hlscommand=HTTP Live Streaming (HLS) command
 advancedsettings.jukeboxcommand=Jukebox command
 advancedsettings.videoimagecommand=Video image extraction command
@@ -480,6 +482,8 @@ musicfoldersettings.scannow=Scan media folders now
 musicfoldersettings.access=Manage user access
 musicfoldersettings.access.description=Configure which folders each user is allowed to access.
 musicfoldersettings.ignoresymlinks=Ignore Symbolic Links
+musicfoldersettings.hideindexedfiles=Hide cue-indexed files
+musicfoldersettings.hideindexedfiles.description=Do not show cue-indexed base files, only show tracks indexed from such files. This option only affects cue-indexed files.
 musicfoldersettings.excludepattern=Exclude pattern
 musicfoldersettings.fastcache=Fast access mode
 musicfoldersettings.fastcache.description=Use this option to minimize disk access, for instance if your media files are located on a network share. Note: Changed or added files will only be visible after your media folders are scanned.
@@ -504,7 +508,7 @@ transcodingsettings.noname=Please specify a name.
 transcodingsettings.nosourceformat=Please specify the format to convert from.
 transcodingsettings.notargetformat=Please specify the format to convert to.
 transcodingsettings.nostep1=Please specify at least one transcoding step.
-transcodingsettings.info=<p class="detail">Available Substitutions:</p><p class="detail" style="margin-left:30px">%s = The file name to be transcoded<br>%b = Max allowed bitrate of the user/player<br>%o = Time offset into the file (used for scrubbing/segmenting)<br>%d = Time duration to play (used for HLS/segmenting)<br>%w = Video image width<br>%h = Video image height<br>%t = Title<br>%a = Artist<br>%l = Album<br>%v = Average video rate (based on max rate)<br>%r = Audio rate in videos (based on max rate)<br>%i = Audio track index<br>%j = HLS segment index<br>%n = HLS segment file name pattern<br>%p = Output filename</p><p>Transcoding is the process of converting from one media format to another, or modifying the media properties. {1}''s transcoding engine allows streaming media that would not otherwise be playable by certain clients. Transcoding is performed on-the-fly and doesn''t require any extra storage space, but does require that the server have sufficient processing resources to transcode the particular format faster than real-time.</p> <p>The transcoding is performed using a third-party command line program, which must be installed in {0}. You may add your own custom transcoder given it fulfills the following requirements: <ul> <li>Command line interface.</li> <li>Ability to send output to stdout.</li> <li>If used in step 2, it must have the ability to read input from stdin.</li> </ul> </p> <p> Note that transcoding is activated on a per-player basis from <b>Settings \u2192 Players</b>, but may also be activated if the server administrator requires it.</p>
+transcodingsettings.info=<p class="detail">Available Substitutions:</p><p class="detail" style="margin-left:30px">%s = The file name to be transcoded<br>%S = Placeholder for split options (used for splitting out indexed tracks)<br>%b = Max allowed bitrate of the user/player<br>%o = Time offset into the file (used for scrubbing/segmenting and splitting)<br>%d = Time duration to play (used for HLS/segmenting and splitting)<br>%f = Target container format (used for splitting)<br>%w = Video image width<br>%h = Video image height<br>%t = Title<br>%a = Artist<br>%l = Album<br>%v = Average video rate (based on max rate)<br>%r = Audio rate in videos (based on max rate)<br>%i = Audio track index<br>%j = HLS segment index<br>%n = HLS segment file name pattern<br>%p = Output filename</p><p>Transcoding is the process of converting from one media format to another, or modifying the media properties. {1}''s transcoding engine allows streaming media that would not otherwise be playable by certain clients. Transcoding is performed on-the-fly and doesn''t require any extra storage space, but does require that the server have sufficient processing resources to transcode the particular format faster than real-time.</p> <p>The transcoding is performed using a third-party command line program, which must be installed in {0}. You may add your own custom transcoder given it fulfills the following requirements: <ul> <li>Command line interface.</li> <li>Ability to send output to stdout.</li> <li>If used in step 2, it must have the ability to read input from stdin.</li> </ul> </p> <p> Note that transcoding is activated on a per-player basis from <b>Settings \u2192 Players</b>, but may also be activated if the server administrator requires it.</p>
 
 internetradiosettings.streamurl=Stream URL
 internetradiosettings.homepageurl=Homepage
@@ -817,6 +821,8 @@ helppopup.excludepattern.title=Exclude Pattern
 helppopup.excludepattern.text=Airsonic will not import any files matching this regular expression pattern.
 helppopup.playlistfolder.title=Import playlist from
 helppopup.playlistfolder.text=Playlists in this folder will be imported reqularly.
+helppopup.hideindexedfiles.title=Hide cue-indexed files
+helppopup.hideindexedfiles.text=Hide files for which corresponding cue (index) files are found, only show the tracks indexed from such files. If this option is unset such files are shown as well as tracks indexed from those files. This option only affects cue-indexed files.
 helppopup.fullscan.title=Full Scan
 helppopup.fullscan.text=Makes the system scan every file and retrieve data from it again regardless of previous scan status of the file. Normally (if this setting is not set) the system does a "smart scan" where it looks at file timestamps and only updates file data for newer files.
 helppopup.clearfullscan.title=Clear Full Scan After Next Scan
@@ -835,6 +841,10 @@ helppopup.coverartconcurrency.title=Cover art concurrency
 helppopup.coverartconcurrency.text=Specify the number of cover art thumbnails that can be generated simultaneously (if needed). Higher number means more thumbs can be generated simultaneously, but requires more CPU threads/cores. This setting requires a restart before it takes effect.
 helppopup.downsamplecommand.title=Downsample command
 helppopup.downsamplecommand.text=Allows you to specify the command for downsampling to lower bitrates.</p><p>(%s = The file to be downsampled, %b = Max bitrate of the player, %t = Title, %a = Artist, %l = Album)
+helppopup.splitoptions.title=Split options
+helppopup.splitoptions.text=These are the options needed by the transcoding tool to split out part of a file when playing indexed tracks. This option sequence is spliced into transcoding commands through the <em>%S</em> placeholder when needed.<p>The default split options are "-ss %o -t %d" as used for ffmpeg, these can be changed to enable the use of an alternative transcoder (e.g. SoX).<p>Add <em>%S</em> right after the ffmpeg command to enable optional track splitting, e.g. "ffmpeg %S -i %s...". This gets expanded into "ffmpeg -ss start_position -t duration -i filename ..." when playing indexed tracks, for non-indexed tracks the %S placeholder is removed.
+helppopup.splitcommand.title=Split command
+helppopup.splitcommand.text=Command to be used for splitting (cue-) indexed files into separate tracks where the file otherwise does not need transcoding, see <em>Split options</em> for the options to be used for transcoded files.<p>(%s = The file to be split, %o = offset (in fractional seconds, e.g. 123.5) into the container file, %d = duration (in fractional seconds) of the track, %f = container file format, e.g. 'ogg' or 'mp3'). The default command uses ffmpeg to split files on frame boundaries without transcoding (<em>-acodec copy</em> means 'copy audio content without transcoding').
 helppopup.hlscommand.title=HTTP Live Streaming command
 helppopup.hlscommand.text=The command used to create video segments for Apple''s HTTP Live Streaming (HLS) protocol.
 helppopup.jukeboxcommand.title=Jukebox command

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/musicFolderSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/musicFolderSettings.jsp
@@ -105,6 +105,12 @@
     </div>
 
     <div>
+        <form:checkbox path="hideIndexedFiles" id="hideIndexedFiles"/>
+        <form:label path="hideIndexedFiles"><fmt:message key="musicfoldersettings.hideindexedfiles"/></form:label>
+        <c:import url="helpToolTip.jsp"><c:param name="topic" value="hideindexedfiles"/></c:import>
+    </div>
+
+    <div>
         <form:checkbox path="fullScan" cssClass="checkbox" id="fullScan"/>
         <form:label path="fullScan"><fmt:message key="musicfoldersettings.fullscan"/></form:label>
         <c:import url="helpToolTip.jsp"><c:param name="topic" value="fullscan"/></c:import>

--- a/airsonic-main/src/main/webapp/WEB-INF/jsp/transcodingSettings.jsp
+++ b/airsonic-main/src/main/webapp/WEB-INF/jsp/transcodingSettings.jsp
@@ -71,6 +71,24 @@
         </tr>
         <tr>
             <td style="font-weight: bold;">
+                <fmt:message key="advancedsettings.splitoptions"/>
+                <c:import url="helpToolTip.jsp"><c:param name="topic" value="splitoptions"/></c:import>
+            </td>
+            <td>
+                <input class="monospace" type="text" name="splitOptions" size="100" value="${model.splitOptions}"/>
+            </td>
+        </tr>
+        <tr>
+            <td style="font-weight: bold;">
+                <fmt:message key="advancedsettings.splitcommand"/>
+                <c:import url="helpToolTip.jsp"><c:param name="topic" value="splitcommand"/></c:import>
+            </td>
+            <td>
+                <input class="monospace" type="text" name="splitCommand" size="100" value="${model.splitCommand}"/>
+            </td>
+        </tr>
+        <tr>
+            <td style="font-weight: bold;">
                 <fmt:message key="advancedsettings.hlscommand"/>
                 <c:import url="helpToolTip.jsp"><c:param name="topic" value="hlscommand"/></c:import>
             </td>


### PR DESCRIPTION
This change adds support for cue-indexed files. Indexed tracks are added to the database using their relative position in the parent file and are played individually by means of a "split" transcoding which is inserted into the transcoding chain. Base files - the files from which tracks are indexed - are shown or hidden depending on whether the 'Hide cue-indexed files' option (on the Media Folders settings page) is set or not. Cue-indexed tracks are represented in the database by their path and start position. The start position is stored in a new 'start_position' field in the database with a default value of '-1.0' - negative values indicate non-indexed files.

New settings:

 - Media Folders/Hide cue-indexed files (boolean): show (unset) or hide (set) cue-indexed base files
 - Transcoding/Split command (text): command used to split off section of a file for streaming, the default command `ffmpeg -ss %o -t %d -i %s -vcodec copy -acodec copy -f %f -` achieves this without transcoding (i.e. lossless) by splitting on frame boundaries.

This is a continuation of the cue-support patch I submitted to the original airsonic (airsonic/airsonic#856) which never got merged. This version has been refactored for airsonic-advanced, rebased on the recently-merged relative paths PR (airsonic-advanced#659), put on display in the bottom of a locked filing cabinet stuck in a disused lavatory with a sign on the door saying ‘Beware of the Leopard" to be finally (?) resubmitted as a new PR.

Database changes:

 - add column `start_position` (double) default -1.0 (used to identify and access indexed tracks)
 - add column `index_path` varchar (used to store and identify indexed files)
 - drop unique index on path+folder_id
 - add unique index on path+folder_id+start_position