### PR TITLE
Fix problem with path names containing periods (.) being truncated after the last occurrence of such (fixes #767)

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -214,7 +214,7 @@ public class MediaFile {
     }
 
     public String getName() {
-        return title != null ? title : FilenameUtils.getBaseName(path);
+        return title != null ? title : isDirectory() ? FilenameUtils.getName(path) : FilenameUtils.getBaseName(path);
     }
 
     public Integer getDiscNumber() {


### PR DESCRIPTION
Path names with periods (.) in them get truncated after the last occurrence of such - fix this (Fixes #767 ).