### PR TITLE
add maven.config

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo ${{ steps.buildx.outputs.platforms }}
       - run: mkdir -p ${DEFAULT_MUSIC_FOLDER}
       - name: Build with Maven
-        run: mvn --settings=./.mvn/settings.xml -DexcludedGroups=${EXCLUDED_TEST_GROUPS} -Ddocker.testing.default-music-folder=${DEFAULT_MUSIC_FOLDER} verify -B -P integration-test
+        run: mvn -DexcludedGroups=${EXCLUDED_TEST_GROUPS} -Ddocker.testing.default-music-folder=${DEFAULT_MUSIC_FOLDER} verify -B -P integration-test
       - name: Calculate tags
         if: success()
         id: tagcalc

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -30,7 +30,7 @@ jobs:
       - run: ${{ matrix.cfg.run }}
         if: matrix.cfg.executeManualcommand
       - name: Build with Maven
-        run: mvn --settings=./.mvn/settings.xml -DexcludedGroups=${EXCLUDED_TEST_GROUPS} -Ddocker.testing.default-music-folder=${DEFAULT_MUSIC_FOLDER} verify -B -P integration-test
+        run: mvn -DexcludedGroups=${EXCLUDED_TEST_GROUPS} -Ddocker.testing.default-music-folder=${DEFAULT_MUSIC_FOLDER} verify -B -P integration-test
 
     strategy:
       fail-fast: false

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -23,7 +23,7 @@ jobs:
             ${{ runner.os }}-m2-
       - run: mvn versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
       - name: Build with Maven
-        run: mvn --settings=./.mvn/settings.xml -DskipTests -Dcheckstyle.skip=true package -P docker
+        run: mvn -DskipTests -Dcheckstyle.skip=true package -P docker
       - name: Calculate tags
         if: success()
         id: tagcalc

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--settings ./.mvn/settings.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,14 +9,14 @@ If you want to run the testsuite and get a `.war` is everything went fine,
 you this command:
 
 ```
- mvn --settings=./.mvn/settings.xml clean package
+ mvn clean package
 ```
 
 If you don't care about the result of the testsuite, but only
 want a `.war` as quick as possible, you can use this instead:
 
 ```
-mvn --settings=./.mvn/settings.xml -DskipTests -Dcheckstyle.skip=true clean package
+mvn -DskipTests -Dcheckstyle.skip=true clean package
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Please use the [Airsonic documentation](https://airsonic.github.io/docs/) for in
 ### Building/Compiling
 You may compile the code yourself by using maven. One of the repositories does not have https, so you may need to allow that for maven. A custom `settings.xml` has been put in `.mvn` folder for this purpose. A sample invocation would be (in the root):
 ```
-mvn --settings=./.mvn/settings.xml clean compile package verify
+mvn clean compile package verify
 ```
 The main binary would be in `airsonic-main/target`
 


### PR DESCRIPTION
Adds [maven.config file](https://maven.apache.org/configure.html#mvn-maven-config-file) which allows running `mvn` command without specify settings file every time.
