### PR TITLE
Playlist Import Resolution

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
@@ -71,6 +71,10 @@ public class MediaFileDao extends AbstractDao {
         return queryOne("select " + QUERY_COLUMNS + " from media_file where id=?", rowMapper, id);
     }
 
+    public List<MediaFile> getMediaFilesByRelativePath(String path) {
+        return query("select " + QUERY_COLUMNS + " from media_file where path=?", rowMapper, path);
+    }
+
     /**
      * Returns the media file that are direct children of the given path.
      *

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -151,6 +151,10 @@ public class MediaFileService {
         return checkLastModified(mediaFile, mediaFolderService.getMusicFolderById(mediaFile.getFolderId()), settingsService.isFastCacheEnabled());
     }
 
+    public List<MediaFile> getMediaFilesByRelativePath(Path relativePath) {
+        return mediaFileDao.getMediaFilesByRelativePath(relativePath.toString());
+    }
+
     public MediaFile getParentOf(MediaFile mediaFile) {
         if (mediaFile.getParentPath() == null) {
             return null;

--- a/airsonic-main/src/main/java/org/airsonic/player/service/playlist/DefaultPlaylistImportHandler.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/playlist/DefaultPlaylistImportHandler.java
@@ -2,28 +2,16 @@ package org.airsonic.player.service.playlist;
 
 import chameleon.playlist.*;
 import org.airsonic.player.domain.MediaFile;
-import org.airsonic.player.service.MediaFileService;
-import org.airsonic.player.service.SettingsService;
 import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.Ordered;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Component
-public class DefaultPlaylistImportHandler implements PlaylistImportHandler {
-
-    @Autowired
-    MediaFileService mediaFileService;
-
-    @Autowired
-    SettingsService settingsService;
-
+public class DefaultPlaylistImportHandler extends PlaylistImportHandler {
     @Override
     public boolean canHandle(Class<? extends SpecificPlaylist> playlistClass) {
         return true;
@@ -33,14 +21,6 @@ public class DefaultPlaylistImportHandler implements PlaylistImportHandler {
     public Pair<List<MediaFile>, List<String>> handle(SpecificPlaylist inputSpecificPlaylist, Path location) {
         List<MediaFile> mediaFiles = new ArrayList<>();
         List<String> errors = new ArrayList<>();
-
-        if (location == null) {
-            location = Optional.ofNullable(settingsService.getPlaylistFolder()).map(Paths::get).orElse(null);
-        }
-        if (location == null) {
-            location = Paths.get(".").toAbsolutePath().normalize();
-        }
-        Path playlistFolder = location;
         try {
             inputSpecificPlaylist.toPlaylist().acceptDown(new BasePlaylistVisitor() {
                 @Override
@@ -49,13 +29,11 @@ public class DefaultPlaylistImportHandler implements PlaylistImportHandler {
                         // Cannot use uri directly because it resolves against war root
                         // URI uri = media.getSource().getURI();
                         String uri = media.getSource().toString();
-                        Path file = Paths.get(uri);
-                        Path resolvedFile = playlistFolder.resolve(file).normalize();
-                        MediaFile mediaFile = mediaFileService.getMediaFile(resolvedFile);
-                        if (mediaFile != null) {
-                            mediaFiles.add(mediaFile);
+                        List<MediaFile> possibles = getMediaFiles(uri);
+                        if (possibles.isEmpty()) {
+                            errors.add("Cannot find media file " + uri);
                         } else {
-                            errors.add("Cannot find media file " + file + "[" + resolvedFile + "]");
+                            mediaFiles.addAll(possibles);
                         }
                     } catch (Exception e) {
                         errors.add(e.getMessage());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/playlist/PlaylistImportHandler.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/playlist/PlaylistImportHandler.java
@@ -2,14 +2,75 @@ package org.airsonic.player.service.playlist;
 
 import chameleon.playlist.SpecificPlaylist;
 import org.airsonic.player.domain.MediaFile;
+import org.airsonic.player.domain.MediaFile.MediaType;
+import org.airsonic.player.service.MediaFileService;
+import org.airsonic.player.service.SettingsService;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.Ordered;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 
-public interface PlaylistImportHandler extends Ordered {
-    boolean canHandle(Class<? extends SpecificPlaylist> playlistClass);
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 
-    Pair<List<MediaFile>, List<String>> handle(SpecificPlaylist inputSpecificPlaylist, Path location);
+public abstract class PlaylistImportHandler implements Ordered {
+    @Autowired
+    MediaFileService mediaFileService;
+
+    @Autowired
+    SettingsService settingsService;
+
+    abstract boolean canHandle(Class<? extends SpecificPlaylist> playlistClass);
+
+    abstract Pair<List<MediaFile>, List<String>> handle(SpecificPlaylist inputSpecificPlaylist, Path location);
+
+    List<MediaFile> getMediaFiles(String pathInPlaylist) {
+        if (StringUtils.isNotBlank(pathInPlaylist)) {
+            Path path = Paths.get(pathInPlaylist);
+            if (path.isAbsolute()) {
+                // there's only one path to look up
+                MediaFile m = mediaFileService.getMediaFile(path);
+                if (m != null) {
+                    return singletonList(m);
+                }
+            } else {
+                // need to resolve the root
+                List<MediaFile> possibles = new ArrayList<>();
+
+                // look relative to playlist folder first
+                Path playlistFolder = Optional.ofNullable(settingsService.getPlaylistFolder()).map(Paths::get).orElse(null);
+                if (playlistFolder != null) {
+                    Path resolvedFile = playlistFolder.resolve(path).normalize();
+                    MediaFile mediaFile = mediaFileService.getMediaFile(resolvedFile);
+                    if (mediaFile != null) {
+                        possibles.add(mediaFile);
+                    }
+                }
+
+                // look relative to all music folders
+                possibles.addAll(mediaFileService.getMediaFilesByRelativePath(path).stream()
+                        .filter(m -> !EnumSet.of(MediaType.DIRECTORY, MediaType.ALBUM).contains(m.getMediaType()))
+                        .collect(toList()));
+
+                // look relative to home
+                Path resolvedFile = Paths.get(".").toAbsolutePath().resolve(path).normalize();
+                MediaFile mediaFile = mediaFileService.getMediaFile(resolvedFile);
+                if (mediaFile != null) {
+                    possibles.add(mediaFile);
+                }
+
+                return possibles;
+            }
+        }
+
+        return emptyList();
+    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/playlist/PlaylistImportHandler.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/playlist/PlaylistImportHandler.java
@@ -28,9 +28,9 @@ public abstract class PlaylistImportHandler implements Ordered {
     @Autowired
     SettingsService settingsService;
 
-    abstract boolean canHandle(Class<? extends SpecificPlaylist> playlistClass);
+    abstract public boolean canHandle(Class<? extends SpecificPlaylist> playlistClass);
 
-    abstract Pair<List<MediaFile>, List<String>> handle(SpecificPlaylist inputSpecificPlaylist, Path location);
+    abstract public Pair<List<MediaFile>, List<String>> handle(SpecificPlaylist inputSpecificPlaylist, Path location);
 
     List<MediaFile> getMediaFiles(String pathInPlaylist) {
         if (StringUtils.isNotBlank(pathInPlaylist)) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/playlist/XspfPlaylistImportHandler.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/playlist/XspfPlaylistImportHandler.java
@@ -4,28 +4,15 @@ import chameleon.playlist.SpecificPlaylist;
 import chameleon.playlist.xspf.Playlist;
 import chameleon.playlist.xspf.StringContainer;
 import org.airsonic.player.domain.MediaFile;
-import org.airsonic.player.service.MediaFileService;
-import org.airsonic.player.service.SettingsService;
 import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Component
-public class XspfPlaylistImportHandler implements PlaylistImportHandler {
-
-    @Autowired
-    MediaFileService mediaFileService;
-
-    @Autowired
-    SettingsService settingsService;
-
+public class XspfPlaylistImportHandler extends PlaylistImportHandler {
     @Override
     public boolean canHandle(Class<? extends SpecificPlaylist> playlistClass) {
         return Playlist.class.equals(playlistClass);
@@ -36,31 +23,20 @@ public class XspfPlaylistImportHandler implements PlaylistImportHandler {
         List<MediaFile> mediaFiles = new ArrayList<>();
         List<String> errors = new ArrayList<>();
         Playlist xspfPlaylist = (Playlist) inputSpecificPlaylist;
-        if (location == null) {
-            location = Optional.ofNullable(settingsService.getPlaylistFolder()).map(Paths::get).orElse(null);
-        }
-        if (location == null) {
-            location = Paths.get(".").toAbsolutePath().normalize();
-        }
-        Path playlistFolder = location;
+
         xspfPlaylist.getTracks().forEach(track -> {
-            MediaFile mediaFile = null;
             for (StringContainer sc : track.getStringContainers()) {
                 try {
-                    Path file = Paths.get(sc.getText());
-                    Path resolvedFile = playlistFolder.resolve(file).normalize();
-                    mediaFile = mediaFileService.getMediaFile(resolvedFile);
-                } catch (Exception ignored) {
+                    String uri = sc.getText();
+                    List<MediaFile> possibles = getMediaFiles(uri);
+                    if (possibles.isEmpty()) {
+                        errors.add("Cannot find media file " + uri);
+                    } else {
+                        mediaFiles.addAll(possibles);
+                    }
+                } catch (Exception e) {
+                    errors.add(e.getMessage());
                 }
-            }
-            if (mediaFile != null) {
-                mediaFiles.add(mediaFile);
-            } else {
-                String errorMsg = "Could not find media file matching ";
-                try {
-                    errorMsg += track.getStringContainers().stream().map(StringContainer::getText).collect(Collectors.joining(","));
-                } catch (Exception ignored) {}
-                errors.add(errorMsg);
             }
         });
         return Pair.of(mediaFiles, errors);


### PR DESCRIPTION
Playlist import now resolves relative paths against all the following and adds all files matching contained in them:
- playlist home
- all music folders
- directory home (.)

absolute urls are not resolved against anything.

The tradeoff is speed. Playlist import might be slightly slower now because it looks in more places.

TO DO: Look for playlist items only in the folders the user has permission for.