### PR TITLE
Speed up parent retrieval and cover art scan during scanning

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
@@ -380,7 +380,7 @@ public class CoverArtController implements LastModified {
         }
 
         private CoverArtRequest(CoverArt coverArt, Supplier<String> keyGenerator, Supplier<Instant> lastModifiedGenerator) {
-            this.coverArt = coverArt == CoverArtService.NULL_ART ? null : coverArt;
+            this.coverArt = CoverArt.NULL_ART.equals(coverArt) ? null : coverArt;
             this.keyGenerator = keyGenerator;
             this.lastModifiedGenerator = lastModifiedGenerator;
         }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
@@ -380,7 +380,7 @@ public class CoverArtController implements LastModified {
         }
 
         private CoverArtRequest(CoverArt coverArt, Supplier<String> keyGenerator, Supplier<Instant> lastModifiedGenerator) {
-            this.coverArt = coverArt;
+            this.coverArt = coverArt == CoverArtService.NULL_ART ? null : coverArt;
             this.keyGenerator = keyGenerator;
             this.lastModifiedGenerator = lastModifiedGenerator;
         }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -138,7 +138,7 @@ public class DownloadController {
             } else {
                 if (indices == null) {
                     CoverArt art = coverArtService.get(EntityType.MEDIA_FILE, mediaFile.getId());
-                    if (art != CoverArtService.NULL_ART) {
+                    if (!CoverArt.NULL_ART.equals(art)) {
                         additionalFiles = Collections.singletonList(Pair.of(art.getRelativePath(), art.getFolderId()));
                     }
                 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -138,7 +138,7 @@ public class DownloadController {
             } else {
                 if (indices == null) {
                     CoverArt art = coverArtService.get(EntityType.MEDIA_FILE, mediaFile.getId());
-                    if (art != null) {
+                    if (art != CoverArtService.NULL_ART) {
                         additionalFiles = Collections.singletonList(Pair.of(art.getRelativePath(), art.getFolderId()));
                     }
                 }

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -504,7 +504,7 @@ public class SubsonicRESTController {
         jaxbArtist.setName(artist.getName());
         jaxbArtist.setStarred(jaxbWriter.convertDate(artistDao.getArtistStarredDate(artist.getId(), username)));
         jaxbArtist.setAlbumCount(artist.getAlbumCount());
-        if (coverArtService.get(EntityType.ARTIST, artist.getId()) != CoverArtService.NULL_ART) {
+        if (!CoverArt.NULL_ART.equals(coverArtService.get(EntityType.ARTIST, artist.getId()))) {
             jaxbArtist.setCoverArt(CoverArtController.ARTIST_COVERART_PREFIX + artist.getId());
         }
         return jaxbArtist;
@@ -552,7 +552,7 @@ public class SubsonicRESTController {
                 jaxbAlbum.setArtistId(String.valueOf(artist.getId()));
             }
         }
-        if (coverArtService.get(EntityType.ALBUM, album.getId()) != CoverArtService.NULL_ART) {
+        if (!CoverArt.NULL_ART.equals(coverArtService.get(EntityType.ALBUM, album.getId()))) {
             jaxbAlbum.setCoverArt(CoverArtController.ALBUM_COVERART_PREFIX + album.getId());
         }
         jaxbAlbum.setSongCount(album.getSongCount());
@@ -1322,7 +1322,7 @@ public class SubsonicRESTController {
 
     private String findCoverArt(MediaFile mediaFile, MediaFile parent) {
         MediaFile dir = mediaFile.isDirectory() ? mediaFile : parent;
-        if (dir != null && coverArtService.get(EntityType.MEDIA_FILE, dir.getId()) != CoverArtService.NULL_ART) {
+        if (dir != null && !CoverArt.NULL_ART.equals(coverArtService.get(EntityType.MEDIA_FILE, dir.getId()))) {
             return String.valueOf(dir.getId());
         }
         return null;

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -504,7 +504,7 @@ public class SubsonicRESTController {
         jaxbArtist.setName(artist.getName());
         jaxbArtist.setStarred(jaxbWriter.convertDate(artistDao.getArtistStarredDate(artist.getId(), username)));
         jaxbArtist.setAlbumCount(artist.getAlbumCount());
-        if (coverArtService.get(EntityType.ARTIST, artist.getId()) != null) {
+        if (coverArtService.get(EntityType.ARTIST, artist.getId()) != CoverArtService.NULL_ART) {
             jaxbArtist.setCoverArt(CoverArtController.ARTIST_COVERART_PREFIX + artist.getId());
         }
         return jaxbArtist;
@@ -552,7 +552,7 @@ public class SubsonicRESTController {
                 jaxbAlbum.setArtistId(String.valueOf(artist.getId()));
             }
         }
-        if (coverArtService.get(EntityType.ALBUM, album.getId()) != null) {
+        if (coverArtService.get(EntityType.ALBUM, album.getId()) != CoverArtService.NULL_ART) {
             jaxbAlbum.setCoverArt(CoverArtController.ALBUM_COVERART_PREFIX + album.getId());
         }
         jaxbAlbum.setSongCount(album.getSongCount());
@@ -1322,7 +1322,7 @@ public class SubsonicRESTController {
 
     private String findCoverArt(MediaFile mediaFile, MediaFile parent) {
         MediaFile dir = mediaFile.isDirectory() ? mediaFile : parent;
-        if (dir != null && coverArtService.get(EntityType.MEDIA_FILE, dir.getId()) != null) {
+        if (dir != null && coverArtService.get(EntityType.MEDIA_FILE, dir.getId()) != CoverArtService.NULL_ART) {
             return String.valueOf(dir.getId());
         }
         return null;

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/CoverArt.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/CoverArt.java
@@ -14,7 +14,7 @@ public class CoverArt {
     private Instant updated = created;
 
     public enum EntityType {
-        MEDIA_FILE, ALBUM, ARTIST
+        MEDIA_FILE, ALBUM, ARTIST, NONE
     }
 
     public CoverArt(int entityId, EntityType entityType, String path, Integer folderId, boolean overridden) {

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/CoverArt.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/CoverArt.java
@@ -3,6 +3,7 @@ package org.airsonic.player.domain;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.Objects;
 
 public class CoverArt {
     private int entityId;
@@ -16,6 +17,8 @@ public class CoverArt {
     public enum EntityType {
         MEDIA_FILE, ALBUM, ARTIST, NONE
     }
+
+    public final static CoverArt NULL_ART = new CoverArt(-2, EntityType.NONE, null, null, false);
 
     public CoverArt(int entityId, EntityType entityType, String path, Integer folderId, boolean overridden) {
         super();
@@ -96,4 +99,24 @@ public class CoverArt {
         this.updated = updated;
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(entityId, entityType);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        CoverArt other = (CoverArt) obj;
+        if (entityId != other.entityId)
+            return false;
+        if (entityType != other.entityType)
+            return false;
+        return true;
+    }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/CoverArtService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/CoverArtService.java
@@ -24,8 +24,6 @@ public class CoverArtService {
     @Autowired
     MediaFolderService mediaFolderService;
 
-    public final static CoverArt NULL_ART = new CoverArt(-2, EntityType.NONE, null, null, false);
-
     public void upsert(EntityType type, int id, String path, Integer folderId, boolean overridden) {
         CoverArt art = new CoverArt(id, type, path, folderId, overridden);
         upsert(art);
@@ -37,9 +35,9 @@ public class CoverArtService {
     }
 
     public void persistIfNeeded(MediaFile mediaFile) {
-        if (mediaFile.getArt() != null && mediaFile.getArt() != NULL_ART) {
+        if (mediaFile.getArt() != null && !CoverArt.NULL_ART.equals(mediaFile.getArt())) {
             CoverArt art = get(EntityType.MEDIA_FILE, mediaFile.getId());
-            if (art == NULL_ART || !art.getOverridden()) {
+            if (CoverArt.NULL_ART.equals(art) || !art.getOverridden()) {
                 mediaFile.getArt().setEntityId(mediaFile.getId());
                 upsert(mediaFile.getArt());
             }
@@ -48,9 +46,9 @@ public class CoverArtService {
     }
 
     public void persistIfNeeded(Album album) {
-        if (album.getArt() != null && album.getArt() != NULL_ART) {
+        if (album.getArt() != null && !CoverArt.NULL_ART.equals(album.getArt())) {
             CoverArt art = get(EntityType.ALBUM, album.getId());
-            if (art == NULL_ART || !art.getOverridden()) {
+            if (CoverArt.NULL_ART.equals(art) || !art.getOverridden()) {
                 album.getArt().setEntityId(album.getId());
                 upsert(album.getArt());
             }
@@ -59,9 +57,9 @@ public class CoverArtService {
     }
 
     public void persistIfNeeded(Artist artist) {
-        if (artist.getArt() != null && artist.getArt() != NULL_ART) {
+        if (artist.getArt() != null && !CoverArt.NULL_ART.equals(artist.getArt())) {
             CoverArt art = get(EntityType.ARTIST, artist.getId());
-            if (art == NULL_ART || !art.getOverridden()) {
+            if (CoverArt.NULL_ART.equals(art) || !art.getOverridden()) {
                 artist.getArt().setEntityId(artist.getId());
                 upsert(artist.getArt());
             }
@@ -71,7 +69,7 @@ public class CoverArtService {
 
     @Cacheable(key = "#type.toString().concat('-').concat(#id)", unless = "#result == null") // 'unless' condition should never happen, because of null-object pattern
     public CoverArt get(EntityType type, int id) {
-        return Optional.ofNullable(coverArtDao.get(type, id)).orElse(NULL_ART);
+        return Optional.ofNullable(coverArtDao.get(type, id)).orElse(CoverArt.NULL_ART);
     }
 
     public Path getFullPath(EntityType type, int id) {
@@ -80,7 +78,7 @@ public class CoverArtService {
     }
 
     public Path getFullPath(CoverArt art) {
-        if (art != null && art != NULL_ART) {
+        if (art != null && !CoverArt.NULL_ART.equals(art)) {
             if (art.getFolderId() == null) {
                 // null folder ids mean absolute paths
                 return art.getRelativePath();

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -119,6 +119,10 @@ public class MediaFileService {
         return getMediaFile(relativePath, folder, settingsService.isFastCacheEnabled());
     }
 
+    public MediaFile getMediaFile(String relativePath, Integer folderId, boolean minimizeDiskAccess) {
+        return getMediaFile(Paths.get(relativePath), mediaFolderService.getMusicFolderById(folderId), minimizeDiskAccess);
+    }
+
     @Cacheable(cacheNames = "mediaFilePathCache", key = "#relativePath.toString().concat('-').concat(#folder.id)", condition = "#root.target.memoryCacheEnabled", unless = "#result == null")
     public MediaFile getMediaFile(Path relativePath, MusicFolder folder, boolean minimizeDiskAccess) {
         // Look in database.
@@ -156,10 +160,14 @@ public class MediaFileService {
     }
 
     public MediaFile getParentOf(MediaFile mediaFile) {
+        return getParentOf(mediaFile, settingsService.isFastCacheEnabled());
+    }
+
+    public MediaFile getParentOf(MediaFile mediaFile, boolean minimizeDiskAccess) {
         if (mediaFile.getParentPath() == null) {
             return null;
         }
-        return getMediaFile(mediaFile.getParentPath(), mediaFolderService.getMusicFolderById(mediaFile.getFolderId()));
+        return getMediaFile(mediaFile.getParentPath(), mediaFile.getFolderId(), minimizeDiskAccess);
     }
 
     private MediaFile checkLastModified(MediaFile mediaFile, MusicFolder folder, boolean minimizeDiskAccess) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -401,7 +401,7 @@ public class MediaScannerService {
             MediaFile parent = mediaFileService.getParentOf(file, true); // true because the parent has recently already been scanned
             if (parent != null) {
                 CoverArt art = coverArtService.get(EntityType.MEDIA_FILE, parent.getId());
-                if (art != null) {
+                if (art != CoverArtService.NULL_ART) {
                     album.setArt(new CoverArt(-1, EntityType.ALBUM, art.getPath(), art.getFolderId(), false));
                 }
             }
@@ -454,7 +454,7 @@ public class MediaScannerService {
             MediaFile parent = mediaFileService.getParentOf(file, true); // true because the parent has recently already been scanned
             if (parent != null) {
                 CoverArt art = coverArtService.get(EntityType.MEDIA_FILE, parent.getId());
-                if (art != null) {
+                if (art != CoverArtService.NULL_ART) {
                     artist.setArt(new CoverArt(-1, EntityType.ARTIST, art.getPath(), art.getFolderId(), false));
                 }
             }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -398,7 +398,7 @@ public class MediaScannerService {
         }
 
         if (album.getArt() == null) {
-            MediaFile parent = mediaFileService.getParentOf(file);
+            MediaFile parent = mediaFileService.getParentOf(file, true); // true because the parent has recently already been scanned
             if (parent != null) {
                 CoverArt art = coverArtService.get(EntityType.MEDIA_FILE, parent.getId());
                 if (art != null) {
@@ -451,7 +451,7 @@ public class MediaScannerService {
         });
 
         if (artist.getArt() == null) {
-            MediaFile parent = mediaFileService.getParentOf(file);
+            MediaFile parent = mediaFileService.getParentOf(file, true); // true because the parent has recently already been scanned
             if (parent != null) {
                 CoverArt art = coverArtService.get(EntityType.MEDIA_FILE, parent.getId());
                 if (art != null) {

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -401,7 +401,7 @@ public class MediaScannerService {
             MediaFile parent = mediaFileService.getParentOf(file, true); // true because the parent has recently already been scanned
             if (parent != null) {
                 CoverArt art = coverArtService.get(EntityType.MEDIA_FILE, parent.getId());
-                if (art != CoverArtService.NULL_ART) {
+                if (!CoverArt.NULL_ART.equals(art)) {
                     album.setArt(new CoverArt(-1, EntityType.ALBUM, art.getPath(), art.getFolderId(), false));
                 }
             }
@@ -454,7 +454,7 @@ public class MediaScannerService {
             MediaFile parent = mediaFileService.getParentOf(file, true); // true because the parent has recently already been scanned
             if (parent != null) {
                 CoverArt art = coverArtService.get(EntityType.MEDIA_FILE, parent.getId());
-                if (art != CoverArtService.NULL_ART) {
+                if (!CoverArt.NULL_ART.equals(art)) {
                     artist.setArt(new CoverArt(-1, EntityType.ARTIST, art.getPath(), art.getFolderId(), false));
                 }
             }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -422,7 +422,7 @@ public class PodcastService {
 
         CoverArt art = coverArtService.get(EntityType.MEDIA_FILE, channel.getMediaFileId());
         // if its already there, no need to download it again
-        if (art != CoverArtService.NULL_ART) {
+        if (!CoverArt.NULL_ART.equals(art)) {
             return;
         }
         MediaFile channelMediaFile = mediaFileService.getMediaFile(channel.getMediaFileId());

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PodcastService.java
@@ -421,7 +421,8 @@ public class PodcastService {
         }
 
         CoverArt art = coverArtService.get(EntityType.MEDIA_FILE, channel.getMediaFileId());
-        if (art != null) {
+        // if its already there, no need to download it again
+        if (art != CoverArtService.NULL_ART) {
             return;
         }
         MediaFile channelMediaFile = mediaFileService.getMediaFile(channel.getMediaFileId());


### PR DESCRIPTION
Use null-object pattern for cover art to cache nulls from the db
Use minimizeDiskAccess to not check for parent file timestamps or recreate it from scratch.

~Need to ensure that == is the appropriate equality operator for NULL_COVERART in case it serializes and deserializes from the cache~ Using .equals now.

Alleviates or fixes #828 