### PR TITLE
Fix JukeBox

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxLegacySubsonicService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/JukeboxLegacySubsonicService.java
@@ -114,7 +114,7 @@ public class JukeboxLegacySubsonicService implements AudioPlayer.Listener {
                     String command = settingsService.getJukeboxCommand();
                     parameters.setTranscoding(new Transcoding(null, "Jukebox", null, null, command, null, null, false));
                     in = transcodingService.getTranscodedInputStream(parameters);
-                    audioPlayer = audioPlayerFactory.createAudioPlayer(in, this);
+                    audioPlayer = audioPlayerFactory.createAudioPlayer(in, command, this);
                     audioPlayer.setGain(gain);
                     audioPlayer.play();
                     onSongStart(file);

--- a/airsonic-main/src/main/java/org/airsonic/player/service/jukebox/AudioPlayerFactory.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/jukebox/AudioPlayerFactory.java
@@ -8,7 +8,7 @@ import java.io.InputStream;
 @Component
 public class AudioPlayerFactory {
 
-    public AudioPlayer createAudioPlayer(InputStream in, JukeboxLegacySubsonicService jukeboxLegacySubsonicService) throws Exception {
-        return new AudioPlayer(in, jukeboxLegacySubsonicService);
+    public AudioPlayer createAudioPlayer(InputStream in, String command, JukeboxLegacySubsonicService jukeboxLegacySubsonicService) throws Exception {
+        return new AudioPlayer(in, command, jukeboxLegacySubsonicService);
     }
 }

--- a/airsonic-main/src/main/java/org/airsonic/player/service/jukebox/PlayerTest.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/jukebox/PlayerTest.java
@@ -50,8 +50,9 @@ public class PlayerTest implements AudioPlayer.Listener {
     }
 
     private void createPlayer() {
+        String command = "ffmpeg -ss %o -i %s -map 0:0 -v 0 -ar 176400 -ac 2 -f s24be -";
         try {
-            player = new AudioPlayer(new FileInputStream("/Users/sindre/Downloads/sample.au"), this);
+            player = new AudioPlayer(new FileInputStream("/Users/sindre/Downloads/sample.au"), command, this);
         } catch (Exception e) {
             player.close();
             throw new RuntimeException(e);


### PR DESCRIPTION
Get audio information from transcoding commands. 
This PR can get sample rate, bits, channel from Jukebox transcode command. 
For example `ffmpeg -ss %o -i %s -map 0:0 -v 0 -ar 176400 -ac 2 -f s32be -` i use regular to match `-ar` `-ac` `-f`.  
In my system, it works well.

To fix my issue https://github.com/airsonic-advanced/airsonic-advanced/issues/869