### PR TITLE
Check whether track and date are numbers

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
@@ -107,8 +107,8 @@ public class FFmpegParser extends MetaDataParser {
             }
 
             data = getData(result, "date");
-            if (data != null) {
-                metaData.setYear(Integer.valueOf(data));
+            if (NumberUtils.isCreatable(data)) {
+                metaData.setYear(NumberUtils.createInteger(data));
             }
 
             // Find the first (if any) stream that has dimensions and use those.

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
@@ -27,6 +27,7 @@ import org.airsonic.player.service.SettingsService;
 import org.airsonic.player.service.TranscodingService;
 import org.airsonic.player.util.Util;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -101,8 +102,8 @@ public class FFmpegParser extends MetaDataParser {
             metaData.setTitle(getData(result, "title"));
 
             String data = getData(result, "track");
-            if (data != null) {
-                metaData.setTrackNumber(Integer.valueOf(data));
+            if (NumberUtils.isCreatable(data)) {
+                metaData.setTrackNumber(NumberUtils.createInteger(data));
             }
 
             data = getData(result, "date");


### PR DESCRIPTION
In FFmpegParser, when parsing JSON data, because the trackNumber and year fields in MetaData are of integer type, you need to judge whether it is a number when converting string to int.

To fix issue #887
