### PR TITLE
Update Docker image to Java 17 and add version tag

### DIFF
--- a/install/docker/Dockerfile
+++ b/install/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:14-jdk-hotspot AS builder
+FROM eclipse-temurin:17.0.7_7-jdk AS builder
 WORKDIR target
 
 COPY run.sh /usr/local/bin/run.sh
@@ -13,7 +13,7 @@ RUN mv WEB-INF/lib lib
 RUN mv WEB-INF/classes/META-INF cMETA-INF
 RUN mv WEB-INF/classes/liquibase cliquibase
 
-FROM adoptopenjdk:14-jre-hotspot
+FROM eclipse-temurin:17.0.7_7-jre
 
 LABEL description="Airsonic-Advanced is a free, web-based media streamer, providing ubiquitous access to your music." \
       url="https://github.com/airsonic-advanced/airsonic-advanced"
@@ -32,7 +32,7 @@ RUN apt-get update && \
                        lame \
                        xmp \
                        bash \
-                       ttf-dejavu \
+                       fonts-dejavu \
                        gosu
 
 COPY --from=builder /usr/local/bin/run.sh /usr/local/bin/run.sh

--- a/install/docker/pom.xml
+++ b/install/docker/pom.xml
@@ -40,7 +40,10 @@
                                     <name>${docker.container.repo}</name>
                                     <build>
                                         <dockerFile>${project.basedir}/Dockerfile</dockerFile>
-                                        <tags>latest</tags>
+                                        <tags>
+                                            <tag>latest</tag>
+                                            <tag>${project.version}</tag>
+                                        </tags>
                                     </build>
                                 </image>
                             </images>


### PR DESCRIPTION
I needed to upgrade the Java version to a newer one to test some new features in Azure like [passwordless access to MySQL databases](https://learn.microsoft.com/azure/developer/java/spring-framework/migrate-mysql-to-passwordless-connection). This PR upgrades to [Java 17 because is the latest LTS](https://endoflife.date/java). 

Changes:

*  Upgrade to [Temurin 17 images](https://hub.docker.com/layers/library/eclipse-temurin/17.0.7_7-jdk/images/sha256-9dd6a19e4819b066aa2bd8e54d5988a49cca29736fe5447cb0a57daa975f8935?context=explore)
* Add current project version to Docker image tag.