### PR TITLE
Updated SystemCallFilter in SystemD service template

### DIFF
--- a/contrib/airsonic.service
+++ b/contrib/airsonic.service
@@ -34,7 +34,7 @@ ProtectKernelTunables=yes
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 RestrictNamespaces=yes
 RestrictRealtime=yes
-SystemCallFilter=~@clock @debug @module @mount @obsolete @privileged @reboot @setuid @swap
+SystemCallFilter=@basic-io @file-system @chown @network-io @sync @timer @signal @process @system-service
 ReadWritePaths=/var/airsonic
 
 # You can change the following line to `strict` instead of `full`


### PR DESCRIPTION
Should fix https://github.com/airsonic-advanced/airsonic-advanced/issues/846 and other crashes related to backup.

See https://github.com/airsonic-advanced/airsonic-advanced/issues/846#issuecomment-2008312228 for a detailed explanation on the reason behind this change.

I see I didn't sign this commit (edited online here on GitHub, don't know if it's possible to sign a commit from there?), but I do acknowledge the licensing requirements of contributions.